### PR TITLE
It should run "make release-binaries" to generate bin/agent-linux-amd…

### DIFF
--- a/test/How-to.md
+++ b/test/How-to.md
@@ -97,7 +97,7 @@ kubectl get machines
 
 ### Add one or more hosts to the capacity pool
 
-(from the folder where Cluster-API source code is cloned)
+(from the folder where Cluster-API-Provider-BYOH source code is cloned)
 
 Create an unmanaged host.
 


### PR DESCRIPTION
…64 under Cluster-API-Provider-BYOH folder, not Cluster-API folder

Signed-off-by: Hui Chen <huchen@huchen-a01.vmware.com>