### PR TITLE
Fix rbac to secrets for byomachine controller

### DIFF
--- a/controllers/byomachine_controller.go
+++ b/controllers/byomachine_controller.go
@@ -46,6 +46,7 @@ type ByoMachineReconciler struct {
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=clusters;machines,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machines/status,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 
 func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req reconcile.Request) (ctrl.Result, error) {
 	_ = r.Log.WithValues("Byomachine", req.NamespacedName)


### PR DESCRIPTION
I had wrongly modified the rbac yaml directly instead of modifying the
generators for kubebuilder to generate