### PR TITLE
Fix intermittent errors in byomachine_controller

### DIFF
--- a/api/v1alpha4/byomachine_types.go
+++ b/api/v1alpha4/byomachine_types.go
@@ -35,6 +35,7 @@ type ByoMachineSpec struct {
 type ByoMachineStatus struct {
 	// INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
 	// Important: Run "make" to regenerate code after modifying this file
+	// +optional
 	Ready bool `json:"ready"`
 
 	// Conditions defines current service state of the BYOMachine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byomachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byomachines.yaml
@@ -91,8 +91,6 @@ spec:
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
                 type: boolean
-            required:
-            - ready
             type: object
         type: object
     served: true


### PR DESCRIPTION
To mitigate intermittent errors when Patch operation fails,
we need to return empty result and an error, so that the reconcile loop
will continue to get to the desired state.

The Ready field of ByoMachineStatus has to be optional. Because its
value is set by the Patch operation, and a failure might complain that a
required field is missing