### PR TITLE
Ability to handle the paused annotation on BYOMachine or Clu…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 all: build
 
-test: generate fmt vet manifests run-test
+test: generate fmt vet manifests run-test agent-test test-e2e
 
 # Run tests
 run-test: 
@@ -88,13 +88,6 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; fetch_envtest_tools $(ENVTEST_ASSETS_DIR); setup_envtest_env $(ENVTEST_ASSETS_DIR); go test `go list ./... | grep -v test/e2e` -coverprofile cover.out
-	
-
 ##@ Build
 
 build: generate fmt vet ## Build manager binary.
@@ -103,7 +96,7 @@ build: generate fmt vet ## Build manager binary.
 run: manifests generate fmt vet ## Run a controller from your host.
 	go run ./main.go
 
-docker-build: test ## Build docker image with the manager.
+docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .
 
 docker-push: ## Push docker image with the manager.

--- a/agent/cloudinit/cloudinit.go
+++ b/agent/cloudinit/cloudinit.go
@@ -1,15 +1,13 @@
 package cloudinit
 
 import (
-	"bytes"
-	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io"
 	"path/filepath"
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	"sigs.k8s.io/yaml"
 )
 
@@ -89,7 +87,7 @@ func decodeContent(content string, encodings []string) (string, error) {
 			}
 			content = string(rByte)
 		case "application/x-gzip":
-			rByte, err := gUnzipData([]byte(content))
+			rByte, err := common.GunzipData([]byte(content))
 			if err != nil {
 				return content, err
 			}
@@ -103,20 +101,3 @@ func decodeContent(content string, encodings []string) (string, error) {
 	return content, nil
 }
 
-func gUnzipData(data []byte) ([]byte, error) {
-	var r io.Reader
-	var err error
-	b := bytes.NewBuffer(data)
-	r, err = gzip.NewReader(b)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	var resB bytes.Buffer
-	_, err = resB.ReadFrom(r)
-	if err != nil {
-		return nil, errors.WithStack(err)
-	}
-
-	return resB.Bytes(), nil
-}

--- a/agent/cloudinit/cloudinit_test.go
+++ b/agent/cloudinit/cloudinit_test.go
@@ -43,12 +43,12 @@ runCmd:
 - echo 'some run command'`, workDir)
 
 			workDir, err = ioutil.TempDir("", "cloudinit_ut")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
 			err := os.RemoveAll(workDir)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should write files successfully", func() {
@@ -73,7 +73,7 @@ runCmd:
   encoding: %s`, fileName1, fileContent1, fileName2, fileBase64Content, permissions, encoding)
 
 			err = scriptExecutor.Execute(bootstrapSecretUnencoded)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeFileWriter.MkdirIfNotExistsCallCount()).To(Equal(2))
 			Expect(fakeFileWriter.WriteToFileCallCount()).To(Equal(2))
@@ -123,7 +123,7 @@ runCmd:
 
 		It("run the command given in the runCmd directive", func() {
 			err := scriptExecutor.Execute(defaultBootstrapSecret)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeCmdExecutor.RunCmdCallCount()).To(Equal(1))
 			cmd := fakeCmdExecutor.RunCmdArgsForCall(0)
@@ -133,7 +133,7 @@ runCmd:
 		It("should not invoke the runCmd or writeFiles directive when absent", func() {
 
 			err := scriptExecutor.Execute("")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(fakeCmdExecutor.RunCmdCallCount()).To(Equal(0))
 			Expect(fakeFileWriter.MkdirIfNotExistsCallCount()).To(Equal(0))

--- a/agent/cloudinit/file_writer_test.go
+++ b/agent/cloudinit/file_writer_test.go
@@ -20,25 +20,25 @@ var _ = Describe("FileWriter", func() {
 
 	BeforeEach(func() {
 		workDir, err = ioutil.TempDir("", "file_writer_ut")
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		err := os.RemoveAll(workDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Should create a directory if it does not exists", func() {
 		err := FileWriter{}.MkdirIfNotExists(workDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Should not create a directory if it already exists", func() {
 		FileWriter{}.MkdirIfNotExists(workDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		err = FileWriter{}.MkdirIfNotExists(workDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("Should create and write to file", func() {
@@ -53,7 +53,7 @@ var _ = Describe("FileWriter", func() {
 		}
 
 		err := FileWriter{}.MkdirIfNotExists(workDir)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(err).NotTo(HaveOccurred())
 
 		err = FileWriter{}.WriteToFile(file)
 		Expect(err).NotTo(HaveOccurred())

--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -27,9 +27,10 @@ var (
 	cfg                   *rest.Config
 	k8sClient             client.Client
 	tmpFilePrefix         = "kubeconfigFile-"
-	clusterName           = "test-cluster"
-	testEnv               *envtest.Environment
-	defaultNamespace      string = "default"
+	//clusterName           = "test-cluster"
+	defaultClusterName = "default-test-cluster"
+	testEnv            *envtest.Environment
+	defaultNamespace   string = "default"
 )
 
 func TestHostAgent(t *testing.T) {
@@ -47,8 +48,8 @@ var _ = BeforeSuite(func() {
 	}
 
 	cfg, err = testEnv.Start()
-	Expect(err).ToNot(HaveOccurred())
-	Expect(cfg).ToNot(BeNil())
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
 
 	scheme := runtime.NewScheme()
 
@@ -65,7 +66,7 @@ var _ = BeforeSuite(func() {
 	writeKubeConfig()
 
 	pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-byoh/agent")
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {
@@ -73,7 +74,7 @@ var _ = AfterSuite(func() {
 	os.Remove(kubeconfigFile.Name())
 	gexec.TerminateAndWait(time.Duration(10) * time.Second)
 	err := testEnv.Stop()
-	Expect(err).ToNot(HaveOccurred())
+	Expect(err).NotTo(HaveOccurred())
 })
 
 func writeKubeConfig() {

--- a/common/testutils.go
+++ b/common/testutils.go
@@ -1,0 +1,145 @@
+package common
+
+import (
+	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+)
+
+
+func NewByoMachine(byoMachineName string, byoMachineNamespace string, clusterName string, machine *clusterv1.Machine) *infrastructurev1alpha4.ByoMachine {
+
+	byoMachine := &infrastructurev1alpha4.ByoMachine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ByoMachine",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      byoMachineName,
+			Namespace: byoMachineNamespace,
+		},
+		Spec: infrastructurev1alpha4.ByoMachineSpec{},
+	}
+
+	if machine != nil {
+		byoMachine.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				Kind:       "Machine",
+				Name:       machine.Name,
+				APIVersion: "cluster.x-k8s.io/v1",
+				UID:        machine.UID,
+			},
+		}
+	} 
+
+	if len(clusterName) > 0 {
+		byoMachine.ObjectMeta.Labels = map[string]string{
+			clusterv1.ClusterLabelName: clusterName,
+		}
+	}
+	return byoMachine
+}
+
+
+func NewMachine(bootstrapSecret *string, machineName string, namespace string, clusterName string) *clusterv1.Machine{
+	machine := &clusterv1.Machine{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Machine",
+			APIVersion: "cluster.x-k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      machineName,
+			Namespace: namespace,
+		},
+		Spec: clusterv1.MachineSpec{
+			Bootstrap: clusterv1.Bootstrap{
+				DataSecretName: bootstrapSecret,
+			},
+			ClusterName: clusterName,
+		},
+	}
+	return machine
+}
+
+
+func NewByoHost(byoHostName string, byoHostNamespace string, byoMachine *infrastructurev1alpha4.ByoMachine) *infrastructurev1alpha4.ByoHost {
+	byoHost := &infrastructurev1alpha4.ByoHost{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "ByoHost",
+			APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      byoHostName,
+			Namespace: byoHostNamespace,
+		},
+		Spec: infrastructurev1alpha4.ByoHostSpec{},
+	}
+
+	if byoMachine != nil {
+		byoHost.Status.MachineRef = &corev1.ObjectReference{
+			Kind:       "ByoMachine",
+			Namespace:  byoMachine.Namespace,
+			Name:       byoMachine.Name,
+			UID:        byoMachine.UID,
+			APIVersion: byoHost.APIVersion,
+		}
+	}
+	return byoHost
+}
+
+func NewNode(nodeName string, namespace string) *corev1.Node{
+	node := &corev1.Node{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Node",
+			APIVersion: "v1alpha4",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nodeName,
+			Namespace: namespace,
+		},
+		Spec:   corev1.NodeSpec{},
+		Status: corev1.NodeStatus{},
+	}
+	return node
+}
+
+func NewCluster(clusterName string, namespace string) *clusterv1.Cluster{
+	cluster := &clusterv1.Cluster{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Cluster",
+			APIVersion: "cluster.x-k8s.io/v1alpha4",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      clusterName,
+			Namespace: namespace,
+		},
+		Spec: clusterv1.ClusterSpec{},
+	}
+	return cluster
+}
+
+func NewNamespace(namespace string) *corev1.Namespace {
+	ns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: namespace},
+	}
+	return ns
+}
+
+func NewSecret(bootstrapSecretName, stringDataValue, namespace string) *corev1.Secret {
+	secret := &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      bootstrapSecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			"value": []byte(stringDataValue),
+		},
+		Type: "cluster.x-k8s.io/secret",
+	}
+	return secret
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -1,0 +1,61 @@
+package common
+
+import (
+	"bytes"
+	"compress/gzip"
+	"io"
+	"math/rand"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+func GzipData(data []byte) ([]byte, error) {
+	var b bytes.Buffer
+	gz := gzip.NewWriter(&b)
+
+	if _, err := gz.Write(data); err != nil {
+		return nil, err
+	}
+
+	if err := gz.Flush(); err != nil {
+		return nil, err
+	}
+
+	if err := gz.Close(); err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func RandStr(prefix string, length int) string {
+	str := "0123456789abcdefghijklmnopqrstuvwxyz"
+	bytes := []byte(str)
+	result := []byte{}
+	rand.Seed(time.Now().UnixNano() + int64(rand.Intn(100)))
+	for i := 0; i < length; i++ {
+		result = append(result, bytes[rand.Intn(len(bytes))])
+	}
+	return prefix + string(result)
+}
+
+
+func GunzipData(data []byte) ([]byte, error) {
+	var r io.Reader
+	var err error
+	b := bytes.NewBuffer(data)
+	r, err = gzip.NewReader(b)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	var resB bytes.Buffer
+	_, err = resB.ReadFrom(r)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+
+	return resB.Bytes(), nil
+}
+

--- a/controllers/infrastructure/byomachine_controller_integration_test.go
+++ b/controllers/infrastructure/byomachine_controller_integration_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -21,12 +22,12 @@ var _ = Describe("Controllers/ByomachineController", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			byoHost = newByoHost(defaultByoHostName, defaultNamespace)
+			byoHost = common.NewByoHost(defaultByoHostName, defaultNamespace, nil)
 			Expect(k8sClient.Create(ctx, byoHost)).Should(Succeed())
 		})
 
 		It("claims the first available host", func() {
-			byoMachine = newByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName)
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName, nil)
 			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
 
 			byoHostLookupKey := types.NamespacedName{Name: byoHost.Name, Namespace: byoHost.Namespace}
@@ -79,7 +80,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 
 			node := corev1.Node{}
 			err := clientFake.Get(ctx, types.NamespacedName{Name: defaultNodeName, Namespace: defaultNamespace}, &node)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(node.Spec.ProviderID).To(ContainSubstring("byoh://"))
 		})

--- a/controllers/infrastructure/byomachine_controller_unit_test.go
+++ b/controllers/infrastructure/byomachine_controller_unit_test.go
@@ -7,7 +7,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	"k8s.io/apimachinery/pkg/types"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
+	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -30,14 +33,14 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 			byoMachineLookupkey := types.NamespacedName{Name: defaultByoMachineName, Namespace: namespace}
 			request := reconcile.Request{NamespacedName: byoMachineLookupkey}
 			_, err := reconciler.Reconcile(ctx, request)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Should not attempt to reconcile when byomachine name does not exist", func() {
 			byoMachineLookupkey := types.NamespacedName{Name: byoMachineName, Namespace: defaultNamespace}
 			request := reconcile.Request{NamespacedName: byoMachineLookupkey}
 			_, err := reconciler.Reconcile(ctx, request)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 	})
@@ -50,7 +53,7 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			byoMachine = newByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName)
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName, nil)
 			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
 		})
 
@@ -79,9 +82,9 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			byoMachine = newByoMachine(defaultByoMachineName, defaultNamespace, clusterName)
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, clusterName, nil)
 			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
-			byoHost = newByoHost(defaultByoHostName, defaultNamespace)
+			byoHost = common.NewByoHost(defaultByoHostName, defaultNamespace, nil)
 			Expect(k8sClient.Create(ctx, byoHost)).Should(Succeed())
 		})
 
@@ -114,9 +117,9 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 
 		BeforeEach(func() {
 			ctx = context.Background()
-			byoMachine = newByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName)
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, defaultClusterName, nil)
 			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
-			byoHost = newByoHost(hostname, defaultNamespace)
+			byoHost = common.NewByoHost(hostname, defaultNamespace, nil)
 			Expect(k8sClient.Create(ctx, byoHost)).Should(Succeed())
 		})
 
@@ -130,6 +133,99 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, byoMachine)).Should(Succeed())
 			Expect(k8sClient.Delete(ctx, byoHost)).Should(Succeed())
+		})
+	})
+
+	Context("When cluster is paused.", func() {
+		const (
+			hostname = "host-unit-test-3"
+			clusterName = "my-cluster-3"
+		)
+
+		var (
+			ctx        context.Context
+			byoMachine *infrastructurev1alpha4.ByoMachine
+			byoHost    *infrastructurev1alpha4.ByoHost
+			cluster    *clusterv1.Cluster
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			cluster = common.NewCluster(clusterName, defaultNamespace)
+			cluster.Spec.Paused = true
+			Expect(k8sClient.Create(ctx, cluster)).Should(Succeed())
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, clusterName, nil)
+			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
+			byoHost = common.NewByoHost(hostname, defaultNamespace, nil)
+			Expect(k8sClient.Create(ctx, byoHost)).Should(Succeed())
+		})
+
+		It("Won't reconcile", func() {
+			byoMachineLookupkey := types.NamespacedName{Name: defaultByoMachineName, Namespace: defaultNamespace}
+			request := reconcile.Request{NamespacedName: byoMachineLookupkey}
+			_, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			createdByoMachine := &infrastructurev1alpha4.ByoMachine{}
+			err = k8sClient.Get(context.TODO(), byoMachineLookupkey, createdByoMachine)
+			Expect(err).NotTo(HaveOccurred())
+
+			readyCondition := conditions.Get(createdByoMachine, infrastructurev1alpha4.HostReadyCondition)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readyCondition).To(BeNil())
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, byoMachine)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, byoHost)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, cluster)).Should(Succeed())
+		})
+	})
+
+	Context("When ByoMachine is paused.", func() {
+		const (
+			hostname = "host-unit-test-4"
+			clusterName = "my-cluster-4"
+		)
+
+		var (
+			ctx        context.Context
+			byoMachine *infrastructurev1alpha4.ByoMachine
+			byoHost    *infrastructurev1alpha4.ByoHost
+			cluster    *clusterv1.Cluster
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			cluster = common.NewCluster(clusterName, defaultNamespace)
+			Expect(k8sClient.Create(ctx, cluster)).Should(Succeed())
+			byoMachine = common.NewByoMachine(defaultByoMachineName, defaultNamespace, clusterName, nil)
+			byoMachine.ObjectMeta.Annotations = map[string]string{}
+			byoMachine.ObjectMeta.Annotations[clusterv1.PausedAnnotation] = "paused"
+			Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
+			byoHost = common.NewByoHost(hostname, defaultNamespace, nil)
+			Expect(k8sClient.Create(ctx, byoHost)).Should(Succeed())
+		})
+
+		It("Won't reconcile", func() {
+			byoMachineLookupkey := types.NamespacedName{Name: defaultByoMachineName, Namespace: defaultNamespace}
+			request := reconcile.Request{NamespacedName: byoMachineLookupkey}
+			_, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+
+			createdByoMachine := &infrastructurev1alpha4.ByoMachine{}
+			err = k8sClient.Get(context.TODO(), byoMachineLookupkey, createdByoMachine)
+			Expect(err).NotTo(HaveOccurred())
+
+			readyCondition := conditions.Get(createdByoMachine, infrastructurev1alpha4.HostReadyCondition)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(readyCondition).To(BeNil())
+		})
+
+		AfterEach(func() {
+			Expect(k8sClient.Delete(ctx, byoMachine)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, byoHost)).Should(Succeed())
+			Expect(k8sClient.Delete(ctx, cluster)).Should(Succeed())
 		})
 	})
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -154,7 +154,7 @@ func initScheme() *runtime.Scheme {
 
 func loadE2EConfig(configPath string) *clusterctl.E2EConfig {
 	config := clusterctl.LoadE2EConfig(context.TODO(), clusterctl.LoadE2EConfigInput{ConfigPath: configPath})
-	Expect(config).ToNot(BeNil(), "Failed to load E2E config from %s", configPath)
+	Expect(config).NotTo(BeNil(), "Failed to load E2E config from %s", configPath)
 
 	return config
 }
@@ -187,14 +187,14 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),
 		})
-		Expect(clusterProvider).ToNot(BeNil(), "Failed to create a bootstrap cluster")
+		Expect(clusterProvider).NotTo(BeNil(), "Failed to create a bootstrap cluster")
 
 		kubeconfigPath = clusterProvider.GetKubeconfigPath()
 		Expect(kubeconfigPath).To(BeAnExistingFile(), "Failed to get the kubeconfig file for the bootstrap cluster")
 	}
 
 	clusterProxy := framework.NewClusterProxy("bootstrap", kubeconfigPath, scheme)
-	Expect(clusterProxy).ToNot(BeNil(), "Failed to get a bootstrap cluster proxy")
+	Expect(clusterProxy).NotTo(BeNil(), "Failed to get a bootstrap cluster proxy")
 
 	return clusterProvider, clusterProxy
 }


### PR DESCRIPTION
1) Stop to reconcile if receive paused annotation on byohost, byomachine or cluster.
2) Write tdd case for this feature
3) Fix some issues in Makefile
   3.1) There are two "test" targets, one of them is outdate.
    3.2) It's not right that docker-build depend on test, and test-e2e depend on docker-build
4) Extract public function
5) There are ToNot and NotTo function, only keep NotTo
6) There are clusterapi and clusterv1 to represent package "sigs.k8s.io/cluster-api/api/v1alpha4", only keep clusterv1
7)  When running e2e, write agent log to /tmp directory, it's for debug purpose.


After coding finished, The following test are passed:
    make run-test
    make agent-test
    make test-e2e
    test/test-run.md
