### PR TITLE
Refactor reconciler tests

### DIFF
--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -14,7 +14,6 @@ import (
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var _ = Describe("Byohost Agent Tests", func() {
@@ -52,14 +51,15 @@ var _ = Describe("Byohost Agent Tests", func() {
 			annotations.AddAnnotations(byoHost, map[string]string{
 				clusterv1.PausedAnnotation: "paused",
 			})
-			patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})
+			err = patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})
+			Expect(err).ToNot(HaveOccurred())
 
-			result, err := reconciler.Reconcile(ctx, controllerruntime.Request{
+			result, reconcilerErr := reconciler.Reconcile(ctx, controllerruntime.Request{
 				NamespacedName: byoHostLookupKey,
 			})
 
-			Expect(result).To(Equal(ctrl.Result{}))
-			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(controllerruntime.Result{}))
+			Expect(reconcilerErr).ToNot(HaveOccurred())
 
 			updatedByoHost := &infrastructurev1alpha4.ByoHost{}
 			err = k8sClient.Get(ctx, byoHostLookupKey, updatedByoHost)


### PR DESCRIPTION
I am creating this PR to start a discussion on how we could structure our tests
- I don't think we should be using Eventually in test set ups. We only need Eventually when we don't know if a certain condition / code will be executed in time. In this case, we can be sure that adding the annotation *will* succeed. So there is no need for Eventually block, neither the `if` check for `changed`
- If we move to calling `Reconcile` directly, we don't need Eventually anymore in our assertion either. We now know that reconciliation is done, so we can be confident with our test assertions. 
- There is a conditions matcher that is present in the clusterAPI code base. Reusing to improve readability. 

In general, I like to avoid Eventually statements unless we really need them. They are slower (because they keep retrying for a second), and allow for flakes to exist (because by their nature, they keep retrying). Tests should be deterministic as far as possible.  