### PR TITLE
Enable e2e CI workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,5 +20,8 @@ jobs:
     - name: Install ginkgo
       run: sudo apt-get install golang-ginkgo-dev
 
-    # - name: run e2e test
-    #   run: make test-e2e
+    - name: turn off swap
+      run: sudo swapoff -a
+
+    - name: run e2e test
+      run: make test-e2e

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -163,13 +163,13 @@ func (r ByoMachineReconciler) reconcileNormal(ctx context.Context, byoMachine *i
 	if !cluster.Status.InfrastructureReady {
 		logger.Info("Cluster infrastructure is not ready yet")
 		conditions.MarkFalse(byoMachine, infrav1.BYOHostReady, infrav1.WaitingForClusterInfrastructureReason, clusterv1.ConditionSeverityInfo, "")
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, errors.New("cluster infrastructure is not ready yet")
 	}
 
 	if machine.Spec.Bootstrap.DataSecretName == nil {
 		logger.Info("Bootstrap Data Secret not available yet")
 		conditions.MarkFalse(byoMachine, infrav1.BYOHostReady, infrav1.WaitingForBootstrapDataSecretReason, clusterv1.ConditionSeverityInfo, "")
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, errors.New("bootstrap data secret not available yet")
 	}
 
 	hostsList := &infrav1.ByoHostList{}


### PR DESCRIPTION
1) It need to turn off swap, or it will reporting the following error:
[kubelet-check] It seems like the kubelet isn't running or healthy.
  [kubelet-check] The HTTP call equal to 'curl -sSL http://localhost:10248/healthz' failed with error: Get "http://localhost:10248/healthz": dial tcp [::1]:10248: connect: connection refused.


2) When cluster.Status.InfrastructureReady is false, or machine.Spec.Bootstrap.DataSecretName is nil, it should return error. Or t didn't re-queue and e2e case can't be success.

If byomachine point to a cluster or machine, and the cluster and machine are not ready, we should return an error and re-enqueue the request. Byohmachine controller will not get called when CAPI resources(cluster, machine) get updated, beacuse Byohmachine watch on the change of Byohmachine object, not cluster and machine object.

