### PR TITLE
Add a hack code to output information of e2e case

### DIFF
--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -1,4 +1,4 @@
-package common
+package e2e
 
 import (
 	"bufio"
@@ -12,7 +12,10 @@ import (
 )
 
 const (
-	DefaultFileMode fs.FileMode = 0777
+	DefaultFileMode                       fs.FileMode = 0777
+	ReadByohControllerManagerLogShellFile string      = "/tmp/read-byoh-controller-manager-log.sh"
+	ReadAllPodsShellFile                  string      = "/tmp/read-all-pods.sh"
+	AgentLogFile                          string      = "/tmp/host-agent.log"
 )
 
 func WriteDockerLog(output types.HijackedResponse, outputFile string) *os.File {
@@ -106,4 +109,31 @@ func WriteShellScript(shellFileName string, shellFileContent []string) {
 			return
 		}
 	}
+}
+
+func ShowInfo() {
+	// show swap status
+	// showFileContent("/proc/swaps")
+
+	// show the status of  all pods
+	shellContent := []string{
+		"kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf",
+	}
+	WriteShellScript(ReadAllPodsShellFile, shellContent)
+	ShowFileContent(ReadAllPodsShellFile)
+	ExecuteShellScript(ReadAllPodsShellFile)
+
+	// show the agent log
+	ShowFileContent(AgentLogFile)
+
+	// show byoh-controller-manager logs
+	shellContent = []string{
+		"podNamespace=`kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf | grep byoh-controller-manager | awk '{print $1}'`",
+		"podName=`kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf | grep byoh-controller-manager | awk '{print $2}'`",
+		"kubectl logs -n ${podNamespace} ${podName} --kubeconfig /tmp/mgmt.conf -c manager",
+	}
+
+	WriteShellScript(ReadByohControllerManagerLogShellFile, shellContent)
+	ShowFileContent(ReadByohControllerManagerLogShellFile)
+	ExecuteShellScript(ReadByohControllerManagerLogShellFile)
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -36,7 +36,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
-	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
@@ -44,15 +43,12 @@ import (
 )
 
 const (
-	KubernetesVersion                     = "KUBERNETES_VERSION"
-	CNIPath                               = "CNI"
-	CNIResources                          = "CNI_RESOURCES"
-	IPFamily                              = "IP_FAMILY"
-	KindImage                             = "byoh/node:v1.19.11"
-	TempKubeconfigPath                    = "/tmp/mgmt.conf"
-	ReadByohControllerManagerLogShellFile = "/tmp/read-byoh-controller-manager-log.sh"
-	ReadAllPodsShellFile                  = "/tmp/read-all-pods.sh"
-	AgentLogFile                          = "/tmp/host-agent.log"
+	KubernetesVersion  = "KUBERNETES_VERSION"
+	CNIPath            = "CNI"
+	CNIResources       = "CNI_RESOURCES"
+	IPFamily           = "IP_FAMILY"
+	KindImage          = "byoh/node:v1.19.11"
+	TempKubeconfigPath = "/tmp/mgmt.conf"
 )
 
 type cpConfig struct {
@@ -262,7 +258,7 @@ var _ = Describe("When BYOH joins existing cluster", func() {
 		defer output.Close()
 
 		// read the log of host agent container in backend, and write it
-		f := common.WriteDockerLog(output, AgentLogFile)
+		f := WriteDockerLog(output, AgentLogFile)
 		defer f.Close()
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -309,30 +305,3 @@ var _ = Describe("When BYOH joins existing cluster", func() {
 		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
 	})
 })
-
-func ShowInfo() {
-	// show swap status
-	// showFileContent("/proc/swaps")
-
-	// show the status of  all pods
-	shellContent := []string{
-		"kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf",
-	}
-	common.WriteShellScript(ReadAllPodsShellFile, shellContent)
-	common.ShowFileContent(ReadAllPodsShellFile)
-	common.ExecuteShellScript(ReadAllPodsShellFile)
-
-	// show the agent log
-	common.ShowFileContent(AgentLogFile)
-
-	// show byoh-controller-manager logs
-	shellContent = []string{
-		"podNamespace=`kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf | grep byoh-controller-manager | awk '{print $1}'`",
-		"podName=`kubectl get pods --all-namespaces --kubeconfig /tmp/mgmt.conf | grep byoh-controller-manager | awk '{print $2}'`",
-		"kubectl logs -n ${podNamespace} ${podName} --kubeconfig /tmp/mgmt.conf -c manager",
-	}
-
-	common.WriteShellScript(ReadByohControllerManagerLogShellFile, shellContent)
-	common.ShowFileContent(ReadByohControllerManagerLogShellFile)
-	common.ExecuteShellScript(ReadByohControllerManagerLogShellFile)
-}


### PR DESCRIPTION
There is a big conflict between [pull-68](https://github.com/vmware-tanzu/cluster-api-provider-byoh/pull/68) and main branch, so I create this new PR. And I'll close [pull-68](https://github.com/vmware-tanzu/cluster-api-provider-byoh/pull/68), please continue our discussion here.

Now we are enable e2e CI workflow. Everytime you create a PR, e2e case need to green before merge the PR. As we all know, the e2e case in running in github runner.

And the environment of github runner is very different with workstations, and hard to debug. If you can reproduce this issue of e2e on your local environment, it is fine. But sometimes, the issue only happened on github runner, not workstation. If you meet this, this PR could be useful.

I write some hacker in e2e-test.go to show some important information from that environment, host agent log, byoh-controller-manager-log, and all pods status information. Most time, with those information, you can locate your issue quicker.