### PR TITLE
Add index to byohost.Status.MachineRef

### DIFF
--- a/controllers/infrastructure/byomachine_controller_unit_test.go
+++ b/controllers/infrastructure/byomachine_controller_unit_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 			request := reconcile.Request{NamespacedName: byoMachineLookupkey}
 
 			_, err := reconciler.Reconcile(ctx, request)
-			Expect(err).To(MatchError("clusters.cluster.x-k8s.io \"" + clusterName + "\" not found"))
+			Expect(err).To(MatchError("Cluster.cluster.x-k8s.io \"" + clusterName + "\" not found"))
 		})
 
 		AfterEach(func() {

--- a/controllers/infrastructure/suite_test.go
+++ b/controllers/infrastructure/suite_test.go
@@ -99,15 +99,13 @@ var _ = BeforeSuite(func() {
 
 	//+kubebuilder:scaffold:scheme
 
-	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(k8sClient).NotTo(BeNil())
-
 	k8sManager, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme:             scheme.Scheme,
 		MetricsBindAddress: ":6080",
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	k8sClient = k8sManager.GetClient()
 
 	capiCluster = common.NewCluster(defaultClusterName, defaultNamespace)
 	Expect(k8sClient.Create(context.Background(), capiCluster)).Should(Succeed())


### PR DESCRIPTION
During byomachine `Reconcile`, we need to determine if there is a byohost
that has this byomachine as its `MachineRef`. This will prevent from
attempting to attach to a host again and also in the delete workflow.