### PR TITLE
Remove cluster-label on byohost during delete workflow

### DIFF
--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -452,7 +452,8 @@ func (r *ByoMachineReconciler) removeHostReservation(ctx context.Context, machin
 	// Remove host reservation.
 	machineScope.ByoHost.Status.MachineRef = nil
 
-	// TODO: Remove cluster-label on byohost
+	// Remove cluster-name label
+	delete(machineScope.ByoHost.Labels, clusterv1.ClusterLabelName)
 
 	// Remove the cleanup annotation
 	delete(machineScope.ByoHost.Annotations, hostCleanupAnnotation)

--- a/controllers/infrastructure/byomachine_controller_unit_test.go
+++ b/controllers/infrastructure/byomachine_controller_unit_test.go
@@ -196,6 +196,8 @@ var _ = Describe("Controllers/ByomachineController/Unitests", func() {
 
 			Expect(createdByoHost.Status.MachineRef).To(BeNil())
 
+			Expect(createdByoHost.Labels[clusterv1.ClusterLabelName]).To(BeEmpty())
+
 			byoHostAnnotations := createdByoHost.GetAnnotations()
 			_, ok := byoHostAnnotations[hostCleanupAnnotation]
 			Expect(ok).To(BeFalse())


### PR DESCRIPTION
When removing host reservation, the byomachine controller to remove the
cluster-label it had attached after reserving the host