### PR TITLE
Run kubeadm reset on byohost for byomachine delete

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"os"
 
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/reconciler"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/registration"
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
@@ -68,7 +69,8 @@ func main() {
 	}
 
 	if err = (reconciler.HostReconciler{
-		Client: k8sClient,
+		Client:    k8sClient,
+		CmdRunner: cloudinit.CmdRunner{},
 	}).SetupWithManager(mgr); err != nil {
 		klog.Errorf("unable to create controller, err=%v", err)
 		return

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit"
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
 	corev1 "k8s.io/api/core/v1"
@@ -19,10 +20,14 @@ import (
 )
 
 type HostReconciler struct {
-	Client client.Client
+	Client    client.Client
+	CmdRunner cloudinit.ICmdRunner
 }
 
-const hostCleanupAnnotation = "byoh.infrastructure.cluster.x-k8s.io/unregistering"
+const (
+	hostCleanupAnnotation = "byoh.infrastructure.cluster.x-k8s.io/unregistering"
+	KubeadmResetCommand   = "kubeadm reset --force"
+)
 
 func (r HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	// Fetch the ByoHost instance.
@@ -123,8 +128,23 @@ func (r HostReconciler) SetupWithManager(mgr manager.Manager) error {
 }
 
 func (r HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructurev1alpha4.ByoHost) error {
-	// TODO: run kubeadm reset on the node
+	err := r.resetNode()
+	if err != nil {
+		return err
+	}
 
 	conditions.MarkFalse(byoHost, infrastructurev1alpha4.K8sNodeBootstrapSucceeded, infrastructurev1alpha4.K8sNodeAbsentReason, v1alpha4.ConditionSeverityInfo, "")
+	return nil
+}
+
+func (r *HostReconciler) resetNode() error {
+	klog.Info("Running kubeadm reset...")
+
+	err := r.CmdRunner.RunCmd(KubeadmResetCommand)
+	if err != nil {
+		return errors.Wrapf(err, "failed to exec kubeadm reset")
+	}
+
+	klog.Info("Kubernetes Node reset")
 	return nil
 }

--- a/agent/reconciler/reconciler_suite_test.go
+++ b/agent/reconciler/reconciler_suite_test.go
@@ -7,6 +7,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit/cloudinitfakes"
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -69,7 +70,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	reconciler = &HostReconciler{
-		Client: k8sClient,
+		Client:    k8sClient,
+		CmdRunner: &cloudinitfakes.FakeICmdRunner{},
 	}
 	err = reconciler.SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit/cloudinitfakes"
 	infrastructurev1alpha4 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	corev1 "k8s.io/api/core/v1"
@@ -25,6 +26,7 @@ var _ = Describe("Byohost Agent Tests", func() {
 			hostName         = "test-host"
 			byoHost          *infrastructurev1alpha4.ByoHost
 			byoHostLookupKey types.NamespacedName
+			fakeCmdExecutor  *cloudinitfakes.FakeICmdRunner
 		)
 
 		BeforeEach(func() {
@@ -33,6 +35,8 @@ var _ = Describe("Byohost Agent Tests", func() {
 			Expect(k8sClient.Create(ctx, byoHost)).NotTo(HaveOccurred(), "failed to create byohost")
 			patchHelper, err = patch.NewHelper(byoHost, k8sClient)
 			Expect(err).ShouldNot(HaveOccurred())
+
+			fakeCmdExecutor = &cloudinitfakes.FakeICmdRunner{}
 
 			byoHostLookupKey = types.NamespacedName{Name: byoHost.Name, Namespace: ns}
 		})
@@ -183,6 +187,7 @@ var _ = Describe("Byohost Agent Tests", func() {
 			byoHost.Annotations[hostCleanupAnnotation] = ""
 			Expect(patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).NotTo(HaveOccurred())
 
+			fakeCmdExecutor.RunCmdReturns(nil)
 			result, reconcilerErr := reconciler.Reconcile(ctx, controllerruntime.Request{
 				NamespacedName: byoHostLookupKey,
 			})


### PR DESCRIPTION
As part of node reset, the agent reconciler should execute `kubeadm reset`
on the node. This does a best effort revert of `kubeadm join` / `init`
Also updated the reconciler test to include `FakeCmdRunner` to mock out
`kubeadm reset` execution