### PR TITLE
Need to update test-run.md for latest code

### DIFF
--- a/test/test-run.md
+++ b/test/test-run.md
@@ -59,7 +59,7 @@ __Clone CAPIRepo__
 ```shell
 git clone git@github.com:kubernetes-sigs/cluster-api.git
 cd cluster-api
-#checkout tag v0.4.2 as it supports multiple infra providers
+#checkout tag v0.4.2 as it supports Kubernetes v1.22.0
 git checkout v0.4.2 
 ```
 


### PR DESCRIPTION
It removes the hard code "--ignore-preflight-errors=all", and it needs to  install linux-image-$(uname -r) in the environment which host agent will run on. Or it will reporting the following error:
[ERROR SystemVerification]: failed to parse kernel config: unable to load kernel module: "configs", output: "modprobe: FATAL: Module configs not found in directory /lib/modules/5.4.0-65-generic\n", err: exit status 1
[preflight] If you know
Plus we upgrade kubernete to v.1.22.0 and cluster-api to v0.4.2, it may also need to update test-run.md to adopt it.

Signed-off-by: Chen Hui <huchen@vmware.com>