### PR TITLE
Add build tools annotation to include packages required by build script

### DIFF
--- a/hack/tools/dummy.go
+++ b/hack/tools/dummy.go
@@ -1,5 +1,0 @@
-package dummy
-
-import _ "github.com/onsi/ginkgo/ginkgo"
-
-// This file is required to have this import(slim-sprig dependency) in go.sum

--- a/hack/tools/tools.go
+++ b/hack/tools/tools.go
@@ -1,0 +1,8 @@
+//go:build tools
+
+// This package imports things required by build scripts, to force `go mod` to see them as dependencies
+package tools
+
+import (
+	_ "github.com/onsi/ginkgo/ginkgo"
+)


### PR DESCRIPTION
Without the `//go:build` tools annotation, `make manifests` fails with
import error. We can now use `tools.go` to include any imports required by
build scripts