### PR TITLE
Only 1 node will be cleanup when delete multiple nodes

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -64,6 +64,7 @@ func (r HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl
 		if err != nil {
 			return ctrl.Result{}, err
 		}
+		delete(byoHost.Annotations, hostCleanupAnnotation)
 		return ctrl.Result{}, nil
 	}
 

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -483,9 +483,6 @@ func (r *ByoMachineReconciler) removeHostReservation(ctx context.Context, machin
 	// Remove cluster-name label
 	delete(machineScope.ByoHost.Labels, clusterv1.ClusterLabelName)
 
-	// Remove the cleanup annotation
-	delete(machineScope.ByoHost.Annotations, hostCleanupAnnotation)
-
 	// Issue the patch.
 	return helper.Patch(ctx, machineScope.ByoHost)
 }

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -235,10 +235,6 @@ var _ = Describe("Controllers/ByomachineController", func() {
 						Expect(k8sClientUncached.Get(ctx, byoHostLookupKey, createdByoHost)).NotTo(HaveOccurred())
 						Expect(createdByoHost.Status.MachineRef).To(BeNil())
 						Expect(createdByoHost.Labels[clusterv1.ClusterLabelName]).To(BeEmpty())
-
-						byoHostAnnotations := createdByoHost.GetAnnotations()
-						_, ok := byoHostAnnotations[hostCleanupAnnotation]
-						Expect(ok).To(BeFalse())
 					})
 				})
 			})


### PR DESCRIPTION
Host agent should be responsible to clean up the annoation when the
clean up process finished.

Currently Machine controller will not wait for the clean up process in the
agent side,  sometimes it will cause host not get cleaned

Signed-off-by: Yixing Jia <yixingj@vmware.com>