### PR TITLE
Add an integration test for byohost reconciler to watch its own resource

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/klog"
+	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha4"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -23,6 +24,7 @@ var (
 )
 
 func init() {
+	klog.InitFlags(nil)
 	scheme = runtime.NewScheme()
 	_ = infrastructurev1alpha4.AddToScheme(scheme)
 	_ = corev1.AddToScheme(scheme)
@@ -35,7 +37,7 @@ func init() {
 
 func main() {
 	flag.Parse()
-
+	ctrl.SetLogger(klogr.New())
 	config, err := ctrl.GetConfig()
 	if err != nil {
 		klog.Errorf("error getting kubeconfig, err=%v", err)

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -33,6 +33,10 @@ const (
 )
 
 func (r HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	log := ctrl.LoggerFrom(ctx)
+	log.WithValues("byoHost ", req.Name)
+	log.Info("Reconciling byohost...")
+
 	// Fetch the ByoHost instance.
 	byoHost := &infrastructurev1alpha4.ByoHost{}
 	err := r.Client.Get(ctx, req.NamespacedName, byoHost)


### PR DESCRIPTION
We limit the agent reconciler to watch its own resource. Added the
missing integration test case for the same
Also, added an assertion for `WatchFilterLabel` when the byohost is
created / registered with the management cluster

We assert on the log statement in the `Reconcile` function to verify that it is actually not called for a byohost other than its own

P.S There are some inconsistencies in the usage of klog and controller-runtime's log, we hope to factor that in a separate PR

Signed-off-by: Jamie Monserrate <monserratej@vmware.com>