### PR TITLE
host agent logs not works after the test code refactor

### DIFF
--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -32,6 +32,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		err                error
 		byoHostName        string
 		byohostContainerID string
+		agentLogFile       = "/tmp/host-agent-reuse.log"
 	)
 
 	BeforeEach(func() {
@@ -64,7 +65,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		defer output.Close()
 
 		// read the log of host agent container in backend, and write it
-		f := WriteDockerLog(output, AgentLogFile)
+		f := WriteDockerLog(output, agentLogFile)
 		defer f.Close()
 
 		By("Creating a cluster")
@@ -143,7 +144,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 	JustAfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			ShowInfo()
+			ShowInfo([]string{agentLogFile})
 		}
 	})
 
@@ -159,7 +160,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		os.Remove(AgentLogFile)
+		os.Remove(agentLogFile)
 		os.Remove(ReadByohControllerManagerLogShellFile)
 		os.Remove(ReadAllPodsShellFile)
 	})

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -15,7 +15,6 @@ const (
 	DefaultFileMode                       fs.FileMode = 0777
 	ReadByohControllerManagerLogShellFile string      = "/tmp/read-byoh-controller-manager-log.sh"
 	ReadAllPodsShellFile                  string      = "/tmp/read-all-pods.sh"
-	AgentLogFile                          string      = "/tmp/host-agent.log"
 )
 
 func WriteDockerLog(output types.HijackedResponse, outputFile string) *os.File {
@@ -111,7 +110,7 @@ func WriteShellScript(shellFileName string, shellFileContent []string) {
 	}
 }
 
-func ShowInfo() {
+func ShowInfo(allAgentLogFiles []string) {
 	// show swap status
 	// showFileContent("/proc/swaps")
 
@@ -124,7 +123,9 @@ func ShowInfo() {
 	ExecuteShellScript(ReadAllPodsShellFile)
 
 	// show the agent log
-	ShowFileContent(AgentLogFile)
+	for _, agentLogFile := range allAgentLogFiles {
+		ShowFileContent(agentLogFile)
+	}
 
 	// show byoh-controller-manager logs
 	shellContent = []string{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,6 +53,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		dockerClient       *client.Client
 		err                error
 		byohostContainerID string
+		agentLogFile       = "/tmp/host-agent.log"
 	)
 
 	BeforeEach(func() {
@@ -85,7 +86,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		defer output.Close()
 
 		// read the log of host agent container in backend, and write it
-		f := WriteDockerLog(output, AgentLogFile)
+		f := WriteDockerLog(output, agentLogFile)
 		defer f.Close()
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -111,7 +112,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 
 	JustAfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			ShowInfo()
+			ShowInfo([]string{agentLogFile})
 		}
 	})
 
@@ -127,7 +128,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			Expect(err).NotTo(HaveOccurred())
 		}
 
-		os.Remove(AgentLogFile)
+		os.Remove(agentLogFile)
 		os.Remove(ReadByohControllerManagerLogShellFile)
 		os.Remove(ReadAllPodsShellFile)
 	})

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -30,6 +30,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		byoHostCapacityPool    = 5
 		byoHostName            string
 		allbyohostContainerIDs []string
+		allAgentLogFiles       []string
 	)
 
 	BeforeEach(func() {
@@ -58,9 +59,15 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		By("Creating byohost capacity pool containing 5 hosts")
 		for i := 0; i < byoHostCapacityPool; i++ {
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
-			_, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName, namespace.Name, dockerClient, bootstrapClusterProxy)
+			output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName, namespace.Name, dockerClient, bootstrapClusterProxy)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
+
+			// read the log of host agent container in backend, and write it
+			agentLogFile := fmt.Sprintf("/tmp/host-agent-%d.log", i)
+			f := WriteDockerLog(output, agentLogFile)
+			defer f.Close()
+			allAgentLogFiles = append(allAgentLogFiles, agentLogFile)
 		}
 
 		// TODO: Write agent logs to files for better debugging
@@ -113,7 +120,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 	JustAfterEach(func() {
 		if CurrentGinkgoTestDescription().Failed {
-			ShowInfo()
+			ShowInfo(allAgentLogFiles)
 		}
 	})
 
@@ -132,7 +139,9 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 		}
 
-		os.Remove(AgentLogFile)
+		for _, agentLogFile := range allAgentLogFiles {
+			os.Remove(agentLogFile)
+		}
 		os.Remove(ReadByohControllerManagerLogShellFile)
 		os.Remove(ReadAllPodsShellFile)
 	})


### PR DESCRIPTION
After the test code refactor, host agent logs not works in the following ways:
1) There are three cases in e2e, even if we choose not to delete host agent log, or when the case failed,  the latter host agent log still will overwrite the previous one
2) It didn't output any host agent logs for md_scale_test

Signed-off-by: Hui Chen <huchen@huchen-a01.vmware.com>