### PR TITLE
We should hidden the kubeadm init output in agent log

### DIFF
--- a/agent/cloudinit/cmd_runner.go
+++ b/agent/cloudinit/cmd_runner.go
@@ -1,7 +1,7 @@
 package cloudinit
 
 import (
-	"fmt"
+	"os"
 	"os/exec"
 )
 
@@ -15,7 +15,6 @@ type CmdRunner struct {
 
 func (r CmdRunner) RunCmd(cmd string) error {
 	command := exec.Command("/bin/sh", "-c", cmd)
-	output, err := command.Output()
-	fmt.Println(string(output))
-	return err
+	command.Stderr = os.Stderr
+	return command.Run()
 }


### PR DESCRIPTION
Signed-off-by: Hui Chen <huchen@huchen-a01.vmware.com>