### PR TITLE
Update pause logic in byomachine controller

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog"
 	"sigs.k8s.io/cluster-api/api/v1alpha4"
-	"sigs.k8s.io/cluster-api/util/annotations"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/cluster-api/util/predicates"
@@ -51,13 +50,6 @@ func (r *HostReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctr
 			reterr = err
 		}
 	}()
-
-	// Return early if the object is paused.
-	if annotations.HasPausedAnnotation(byoHost) {
-		klog.Info("The related byoMachine or linked Cluster is marked as paused. Won't reconcile")
-		conditions.MarkFalse(byoHost, infrastructurev1alpha4.K8sNodeBootstrapSucceeded, infrastructurev1alpha4.ClusterOrResourcePausedReason, v1alpha4.ConditionSeverityInfo, "")
-		return ctrl.Result{}, nil
-	}
 
 	// Check for host cleanup annotation
 	hostAnnotations := byoHost.GetAnnotations()
@@ -112,8 +104,6 @@ func (r *HostReconciler) reconcileNormal(ctx context.Context, byoHost *infrastru
 }
 
 func (r *HostReconciler) reconcileDelete(ctx context.Context, byoHost *infrastructurev1alpha4.ByoHost) (ctrl.Result, error) {
-	// TODO: add logic when this host has MachineRef assigned
-
 	return ctrl.Result{}, nil
 }
 
@@ -147,7 +137,7 @@ func (r HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructure
 	// Remove cluster-name label
 	delete(byoHost.Labels, v1alpha4.ClusterLabelName)
 
-	// Remove the cleanup annotation
+	// Remove cleanup annotation
 	delete(byoHost.Annotations, hostCleanupAnnotation)
 
 	conditions.MarkFalse(byoHost, infrastructurev1alpha4.K8sNodeBootstrapSucceeded, infrastructurev1alpha4.K8sNodeAbsentReason, v1alpha4.ConditionSeverityInfo, "")

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -21,14 +21,12 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
@@ -132,18 +130,6 @@ func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}()
 
-	// Return early if the object or Cluster is paused.
-	if annotations.IsPaused(cluster, byoMachine) {
-		logger.Info("byoMachine or linked Cluster is marked as paused. Won't reconcile")
-		if byoMachine.Spec.ProviderID != "" {
-			if err = r.setPausedConditionForByoHost(ctx, byoMachine.Spec.ProviderID, req.Namespace, true); err != nil {
-				logger.Error(err, "Set Paused flag for byohost")
-			}
-		}
-		conditions.MarkFalse(byoMachine, infrav1.BYOHostReady, infrav1.ClusterOrResourcePausedReason, clusterv1.ConditionSeverityInfo, "")
-		return ctrl.Result{}, nil
-	}
-
 	// Fetch the BYOHost which is referencing this machine, if any
 	hostsList := &infrav1.ByoHostList{}
 	err = r.Client.List(
@@ -172,6 +158,18 @@ func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, err
 	}
 
+	// Return early if the object or Cluster is paused.
+	if annotations.IsPaused(cluster, byoMachine) {
+		logger.Info("byoMachine or linked Cluster is marked as paused. Won't reconcile")
+		if machineScope.ByoHost != nil {
+			if err = r.setPausedConditionForByoHost(ctx, machineScope, true); err != nil {
+				logger.Error(err, "cannot set paused annotation for byohost")
+			}
+		}
+		conditions.MarkFalse(byoMachine, infrav1.BYOHostReady, infrav1.ClusterOrResourcePausedReason, clusterv1.ConditionSeverityInfo, "")
+		return ctrl.Result{}, nil
+	}
+
 	// Handle deleted machines
 	if !byoMachine.ObjectMeta.DeletionTimestamp.IsZero() {
 		return r.reconcileDelete(ctx, machineScope)
@@ -195,13 +193,12 @@ func (r *ByoMachineReconciler) reconcileDelete(ctx context.Context, machineScope
 
 func (r *ByoMachineReconciler) reconcileNormal(ctx context.Context, machineScope *byoMachineScope) (reconcile.Result, error) {
 	logger := log.FromContext(ctx).WithValues("namespace", machineScope.ByoMachine.Namespace, "BYOMachine", machineScope.ByoMachine.Name)
-	// TODO: Uncomment below line when we have tests for byomachine delete
+
 	controllerutil.AddFinalizer(machineScope.ByoMachine, infrav1.MachineFinalizer)
 
-	// TODO: Remove the below check after refactoring setting of Pause annotation on byoHost
-	if len(machineScope.ByoMachine.Spec.ProviderID) > 0 {
+	if machineScope.ByoHost != nil {
 		// if there is already byohost associated with it, make sure the paused status of byohost is false
-		if err := r.setPausedConditionForByoHost(ctx, machineScope.ByoMachine.Spec.ProviderID, machineScope.ByoMachine.Namespace, false); err != nil {
+		if err := r.setPausedConditionForByoHost(ctx, machineScope, false); err != nil {
 			logger.Error(err, "Set resume flag for byohost failed")
 			return ctrl.Result{}, err
 		}
@@ -312,44 +309,22 @@ func (r *ByoMachineReconciler) getRemoteClient(ctx context.Context, byoMachine *
 	return remoteClient, nil
 }
 
-func (r *ByoMachineReconciler) setPausedConditionForByoHost(ctx context.Context, providerID, nameSpace string, isPaused bool) error {
-	// The format of providerID is "byoh://<byoHostName>/<RandomString(6)>
-	if !strings.HasPrefix(providerID, providerIDPrefix) {
-		return errors.New("invalid providerID prefix")
-	}
-
-	strs := strings.Split(providerID[len(providerIDPrefix):], "/")
-
-	if len(strs) == 0 {
-		return errors.New("invalid providerID format")
-	}
-
-	byoHostName := strs[0]
-
-	byoHost := &infrav1.ByoHost{}
-	err := r.Client.Get(ctx, types.NamespacedName{Name: byoHostName, Namespace: nameSpace}, byoHost)
-	if err != nil {
-		return err
-	}
-
-	helper, err := patch.NewHelper(byoHost, r.Client)
+func (r *ByoMachineReconciler) setPausedConditionForByoHost(ctx context.Context, machineScope *byoMachineScope, isPaused bool) error {
+	helper, err := patch.NewHelper(machineScope.ByoHost, r.Client)
 	if err != nil {
 		return err
 	}
 
 	if isPaused {
 		desired := map[string]string{
-			clusterv1.PausedAnnotation: "paused",
+			clusterv1.PausedAnnotation: "",
 		}
-		annotations.AddAnnotations(byoHost, desired)
+		annotations.AddAnnotations(machineScope.ByoHost, desired)
 	} else {
-		_, ok := byoHost.Annotations[clusterv1.PausedAnnotation]
-		if ok {
-			delete(byoHost.Annotations, clusterv1.PausedAnnotation)
-		}
+		delete(machineScope.ByoHost.Annotations, clusterv1.PausedAnnotation)
 	}
 
-	return helper.Patch(ctx, byoHost)
+	return helper.Patch(ctx, machineScope.ByoHost)
 }
 
 func (r *ByoMachineReconciler) attachByoHost(ctx context.Context, logger logr.Logger, machineScope *byoMachineScope) (ctrl.Result, error) {


### PR DESCRIPTION
We can use the `machineScope` object to check if the byomachine has an
associated byohost or not. Updating the logic to use this.
Also, removed the pause check in `host-reconciler` because we are
filtering out byohost resources that are paused. Removed the
corresponding test case as well.