### PR TITLE
Enable webhook for byohost

### DIFF
--- a/.github/workflows/test-webhook.yml
+++ b/.github/workflows/test-webhook.yml
@@ -1,0 +1,24 @@
+name: Byoh webhook tests
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  test-byoh-webhook:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Install ginkgo
+      run: sudo apt-get install golang-ginkgo-dev
+
+    - name: test byoh webhook
+      run: make webhook-test

--- a/Makefile
+++ b/Makefile
@@ -50,13 +50,16 @@ SHELL = /usr/bin/env bash -o pipefail
 all: build
 
 # Run tests
-test: generate fmt vet manifests controller-test agent-test
+test: generate fmt vet manifests controller-test agent-test webhook-test
 
 agent-test:
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r agent -coverprofile cover.out
 
 controller-test:
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs controllers/infrastructure -coverprofile cover.out
+
+webhook-test:
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo apis/infrastructure/v1alpha4 -coverprofile cover.out
 
 ##@ General
 

--- a/PROJECT
+++ b/PROJECT
@@ -23,6 +23,9 @@ resources:
   kind: ByoHost
   path: github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1alpha4
   version: v1alpha4
+  webhooks:
+    validation: true
+    webhookVersion: v1
 - api:
     crdVersion: v1
     namespaced: true

--- a/apis/infrastructure/v1alpha4/byohost_webhook.go
+++ b/apis/infrastructure/v1alpha4/byohost_webhook.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var byohostlog = logf.Log.WithName("byohost-resource")
+
+func (h *ByoHost) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(h).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1alpha4-byohost,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=byohosts,verbs=create;update;delete,versions=v1alpha4,name=vbyohost.kb.io,admissionReviewVersions={v1,v1beta1}
+
+var _ webhook.Validator = &ByoHost{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (h *ByoHost) ValidateCreate() error {
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (h *ByoHost) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (h *ByoHost) ValidateDelete() error {
+	byohostlog.Info("validate delete", "name", h.Name)
+	groupResource := schema.GroupResource{Group: "infrastructure.cluster.x-k8s.io", Resource: "byohost"}
+
+	if h.Status.MachineRef != nil {
+		return apierrors.NewForbidden(groupResource, h.Name, errors.New("cannot delete ByoHost when MachineRef is assigned"))
+	}
+
+	return nil
+}

--- a/apis/infrastructure/v1alpha4/byohost_webhook_test.go
+++ b/apis/infrastructure/v1alpha4/byohost_webhook_test.go
@@ -1,0 +1,131 @@
+package v1alpha4
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/kubectl/pkg/scheme"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ByohostWebhook", func() {
+	// TODO: Make the below Context work
+	// we will not need the second context if this works
+	XContext("When ByoHost gets a delete request", func() {
+		var (
+			byoHost           *ByoHost
+			ctx               context.Context
+			k8sClientUncached client.Client
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			var clientErr error
+
+			k8sClientUncached, clientErr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+			Expect(clientErr).NotTo(HaveOccurred())
+
+			byoHost = &ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "byohost-",
+					Namespace:    "default",
+				},
+				Spec: ByoHostSpec{},
+			}
+			Expect(k8sClientUncached.Create(ctx, byoHost)).Should(Succeed())
+		})
+
+		It("should not reject the request", func() {
+			err := byoHost.ValidateDelete()
+			Expect(err).To(BeNil())
+		})
+
+		Context("When ByoHost has MachineRef assigned", func() {
+			var (
+				byoMachine *ByoMachine
+			)
+			BeforeEach(func() {
+				byoMachine = &ByoMachine{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "ByoMachine",
+						APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "byomachine-",
+						Namespace:    "default",
+					},
+					Spec: ByoMachineSpec{},
+				}
+				Expect(k8sClientUncached.Create(ctx, byoMachine)).Should(Succeed())
+
+				ph, err := patch.NewHelper(byoHost, k8sClientUncached)
+				Expect(err).ShouldNot(HaveOccurred())
+				byoHost.Status.MachineRef = &corev1.ObjectReference{
+					Kind:       "ByoMachine",
+					Namespace:  byoMachine.Namespace,
+					Name:       byoMachine.Name,
+					UID:        byoMachine.UID,
+					APIVersion: byoHost.APIVersion,
+				}
+				Expect(ph.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).Should(Succeed())
+			})
+
+			It("should reject the request", func() {
+				err := byoHost.ValidateDelete()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("cannot delete ByoHost when MachineRef is assigned"))
+			})
+		})
+	})
+
+	Context("When ByoHost gets a delete request", func() {
+		var (
+			byoHost ByoHost
+		)
+		BeforeEach(func() {
+			byoHost = ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1alpha4",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "byohost",
+					Namespace: "default",
+				},
+				Spec: ByoHostSpec{},
+				Status: ByoHostStatus{
+					MachineRef: nil,
+				},
+			}
+		})
+
+		It("should not reject the request", func() {
+			err := byoHost.ValidateDelete()
+			Expect(err).To(BeNil())
+		})
+
+		Context("When ByoHost has MachineRef assigned", func() {
+
+			BeforeEach(func() {
+				byoHost.Status.MachineRef = &corev1.ObjectReference{
+					Kind:      "ByoMachine",
+					Namespace: "default",
+					Name:      "byomachine",
+				}
+			})
+
+			It("should reject the request", func() {
+				err := byoHost.ValidateDelete()
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError("byohost.infrastructure.cluster.x-k8s.io \"byohost\" is forbidden: cannot delete ByoHost when MachineRef is assigned"))
+			})
+		})
+	})
+})

--- a/apis/infrastructure/v1alpha4/webhook_suite_test.go
+++ b/apis/infrastructure/v1alpha4/webhook_suite_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha4
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"path/filepath"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	//+kubebuilder:scaffold:imports
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Webhook Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	scheme := runtime.NewScheme()
+	err = AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = admissionv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	// start webhook server using Manager
+	webhookInstallOptions := &testEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme:             scheme,
+		Host:               webhookInstallOptions.LocalServingHost,
+		Port:               webhookInstallOptions.LocalServingPort,
+		CertDir:            webhookInstallOptions.LocalServingCertDir,
+		LeaderElection:     false,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	err = (&ByoHost{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
+	//+kubebuilder:scaffold:webhook
+
+	go func() {
+		err = mgr.Start(ctx)
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+	}()
+
+	// wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true})
+		if err != nil {
+			return err
+		}
+		conn.Close()
+		return nil
+	}).Should(Succeed())
+
+}, 60)
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/config/certmanager/certificate.yaml
+++ b/config/certmanager/certificate.yaml
@@ -1,7 +1,7 @@
 # The following manifests contain a self-signed issuer CR and a certificate CR.
 # More document can be found at https://docs.cert-manager.io
 # WARNING: Targets CertManager 0.11 check https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html for breaking changes
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: selfsigned-issuer
@@ -9,7 +9,7 @@ metadata:
 spec:
   selfSigned: {}
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: serving-cert  # this name should match the one appeared in kustomizeconfig.yaml
@@ -22,4 +22,4 @@ spec:
   issuerRef:
     kind: Issuer
     name: selfsigned-issuer
-  secretName: webhook-server-cert # this secret will not be prefixed, since it's not managed by kustomize
+  secretName: $(SERVICE_NAME)-cert # this secret will not be prefixed, since it's not managed by kustomize

--- a/config/certmanager/kustomizeconfig.yaml
+++ b/config/certmanager/kustomizeconfig.yaml
@@ -14,3 +14,6 @@ varReference:
 - kind: Certificate
   group: cert-manager.io
   path: spec/dnsNames
+- kind: Certificate
+  group: cert-manager.io
+  path: spec/secretName

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -16,7 +16,7 @@ patchesStrategicMerge:
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix.
 # patches here are for enabling the conversion webhook for each CRD
 #- patches/webhook_in_byomachines.yaml
-#- patches/webhook_in_byohosts.yaml
+- patches/webhook_in_byohosts.yaml
 #- patches/webhook_in_byomachinetemplates.yaml
 #- patches/webhook_in_byoclusters.yaml
 #+kubebuilder:scaffold:crdkustomizewebhookpatch
@@ -24,7 +24,7 @@ patchesStrategicMerge:
 # [CERTMANAGER] To enable webhook, uncomment all the sections with [CERTMANAGER] prefix.
 # patches here are for enabling the CA injection for each CRD
 #- patches/cainjection_in_byomachines.yaml
-#- patches/cainjection_in_byohosts.yaml
+- patches/cainjection_in_byohosts.yaml
 #- patches/cainjection_in_byomachinetemplates.yaml
 #- patches/cainjection_in_byoclusters.yaml
 #+kubebuilder:scaffold:crdkustomizecainjectionpatch

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -16,11 +16,8 @@ bases:
 - ../crd
 - ../rbac
 - ../manager
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager
+- ../webhook
+- ../certmanager
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 #- ../prometheus
 
@@ -36,39 +33,42 @@ patchesStrategicMerge:
 
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+- manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+- webhookcainjection_patch.yaml
 
 # the following config is for teaching kustomize how to do var substitution
 vars:
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
-#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: CERTIFICATE_NAME
-#  objref:
-#    kind: Certificate
-#    group: cert-manager.io
-#    version: v1
-#    name: serving-cert # this name should match the one in certificate.yaml
-#- name: SERVICE_NAMESPACE # namespace of the service
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
-#  fieldref:
-#    fieldpath: metadata.namespace
-#- name: SERVICE_NAME
-#  objref:
-#    kind: Service
-#    version: v1
-#    name: webhook-service
+- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+  fieldref:
+    fieldpath: metadata.namespace
+- name: CERTIFICATE_NAME
+  objref:
+    kind: Certificate
+    group: cert-manager.io
+    version: v1
+    name: serving-cert # this name should match the one in certificate.yaml
+- name: SERVICE_NAMESPACE # namespace of the service
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+  fieldref:
+    fieldpath: metadata.namespace
+- name: SERVICE_NAME
+  objref:
+    kind: Service
+    version: v1
+    name: webhook-service
+
+configurations:
+  - kustomizeconfig.yaml

--- a/config/default/kustomizeconfig.yaml
+++ b/config/default/kustomizeconfig.yaml
@@ -1,0 +1,4 @@
+# This configuration is for teaching kustomize how to update name ref and var substitution
+varReference:
+- kind: Deployment
+  path: spec/template/spec/volumes/secret/secretName

--- a/config/default/manager_webhook_patch.yaml
+++ b/config/default/manager_webhook_patch.yaml
@@ -20,4 +20,4 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-cert
+          secretName: $(SERVICE_NAME)-cert

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,13 +1,7 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
-kind: MutatingWebhookConfiguration
-metadata:
-  name: mutating-webhook-configuration
-  annotations:
-    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: validating-webhook-configuration

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -27,6 +27,7 @@ spec:
         - /manager
         args:
         - --enable-leader-election
+        - "--metrics-bind-addr=127.0.0.1:8080"
         image: gcr.io/k8s-staging-cluster-api/caph-manager:latest
         name: manager
         resources:

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,0 +1,6 @@
+resources:
+- manifests.yaml
+- service.yaml
+
+configurations:
+- kustomizeconfig.yaml

--- a/config/webhook/kustomizeconfig.yaml
+++ b/config/webhook/kustomizeconfig.yaml
@@ -1,0 +1,18 @@
+# the following config is for teaching kustomize where to look at when substituting vars.
+# It requires kustomize v2.1.0 or newer to work properly.
+nameReference:
+- kind: Service
+  version: v1
+  fieldSpecs:
+  - kind: ValidatingWebhookConfiguration
+    group: admissionregistration.k8s.io
+    path: webhooks/clientConfig/service/name
+
+namespace:
+- kind: ValidatingWebhookConfiguration
+  group: admissionregistration.k8s.io
+  path: webhooks/clientConfig/service/namespace
+  create: true
+
+varReference:
+- path: metadata/annotations

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,0 +1,30 @@
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: validating-webhook-configuration
+webhooks:
+- admissionReviewVersions:
+  - v1
+  - v1beta1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1alpha4-byohost
+  failurePolicy: Fail
+  name: vbyohost.kb.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1alpha4
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - byohosts
+  sideEffects: None

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -1,0 +1,12 @@
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: system
+spec:
+  ports:
+    - port: 443
+      targetPort: 9443
+  selector:
+    control-plane: controller-manager

--- a/controllers/infrastructure/suite_test.go
+++ b/controllers/infrastructure/suite_test.go
@@ -98,9 +98,6 @@ var _ = BeforeSuite(func() {
 	err = bootstrapv1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = infrastructurev1alpha4.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-
 	//+kubebuilder:scaffold:scheme
 
 	k8sManager, err = ctrl.NewManager(cfg, ctrl.Options{

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	k8s.io/apimachinery v0.21.3
 	k8s.io/client-go v0.21.3
 	k8s.io/klog v1.0.0
+	k8s.io/kubectl v0.21.2
 	k8s.io/utils v0.0.0-20210722164352-7f3ee0f31471
 	sigs.k8s.io/cluster-api v0.4.2
 	sigs.k8s.io/cluster-api/test v0.4.2

--- a/go.sum
+++ b/go.sum
@@ -1717,6 +1717,7 @@ k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
+k8s.io/kubectl v0.21.2 h1:9XPCetvOMDqrIZZXb1Ei+g8t6KrIp9ENJaysQjUuLiE=
 k8s.io/kubectl v0.21.2/go.mod h1:PgeUclpG8VVmmQIl8zpLar3IQEpFc9mrmvlwY3CK1xo=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/metrics v0.21.2/go.mod h1:wzlOINZMCtWq8dR9gHlyaOemmYlOpAoldEIXE82gAhI=

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
@@ -53,6 +54,7 @@ func init() {
 	//+kubebuilder:scaffold:scheme
 
 	utilruntime.Must(clusterv1.AddToScheme(scheme))
+	utilruntime.Must(admissionv1beta1.AddToScheme(scheme))
 }
 
 func main() {
@@ -126,6 +128,10 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ByoCluster")
+		os.Exit(1)
+	}
+	if err = (&infrastructurev1alpha4.ByoHost{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ByoHost")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
Whenever a delete request is received for byohost,
if no `MachineRef` is assigned, delete should proceed
if it has `MachineRef`, then the delete request should be blocked

Added unit tests for the webhook