### PR TITLE
Before bootstrap a node in the agent , it should make sure the /run/kubeadm/ directory is clear

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -152,7 +152,6 @@ func (r HostReconciler) kubeadmDirCleanup(ctx context.Context) error {
 }
 
 func (r HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
-
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("cleaning up host")
 	err := r.resetNode(ctx)


### PR DESCRIPTION
when bootstrap a node , sometime it will have some wired character in the file which prevent the node start up successfully. One possible solution is clear the directory first before bootstrap

Signed-off-by: Hui Chen <huchen@huchen-a01.vmware.com>