### PR TITLE
Add goheader to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,16 @@ linters-settings:
   funlen:
     lines: 100
     statements: 50
+  goheader:
+    values:
+      const:
+        COMPANY: VMware, Inc.
+        LICENSE: Apache-2.0
+      regexp:
+        YEAR: 20\d*-*\d*
+    template: |-
+      Copyright {{ YEAR }} {{ COMPANY }} All Rights Reserved.
+      SPDX-License-Identifier: {{ LICENSE }}
   goconst:
     min-len: 2
     min-occurrences: 2

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package installer
 
 import (
@@ -5,27 +8,28 @@ import (
 )
 
 type Error string
+
 func (e Error) Error() string { return string(e) }
 
 const (
-	ErrDetectOs		= Error("Error detecting OS")
-	ErrOsK8sNotSupported	= Error("No k8s support for OS")
-	ErrBundleDownload       = Error("Error downloading bundle")
-	ErrBundleExtract        = Error("Error extracting bundle")
-	ErrBundleInstall        = Error("Error installing bundle")
-	ErrBundleUninstall      = Error("Error uninstalling bundle")
+	ErrDetectOs          = Error("Error detecting OS")
+	ErrOsK8sNotSupported = Error("No k8s support for OS")
+	ErrBundleDownload    = Error("Error downloading bundle")
+	ErrBundleExtract     = Error("Error extracting bundle")
+	ErrBundleInstall     = Error("Error installing bundle")
+	ErrBundleUninstall   = Error("Error uninstalling bundle")
 )
 
 type installer struct {
-	bundleRepo string
+	bundleRepo   string
 	downloadPath string
-	logger logr.Logger
+	logger       logr.Logger
 }
 
 func New(bundleRepo, downloadPath string, logger logr.Logger) (*installer, error) {
-	return &installer{bundleRepo : bundleRepo,
-	                  downloadPath : downloadPath,
-	                  logger : logger}, nil
+	return &installer{bundleRepo: bundleRepo,
+		downloadPath: downloadPath,
+		logger:       logger}, nil
 }
 
 func (i *installer) Install(k8sVer string) error {
@@ -47,5 +51,5 @@ func ListSupportedK8s(os string) ([]string, error) {
 // PreviewChanges describes the changes to install and uninstall K8s on OS without actually applying them.
 // It returns the install and uninstall changes
 func PreviewChanges(os, k8sVer string) (install, uninstall string, err error) {
-	return "","", nil
+	return "", "", nil
 }

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package installer
 
 import (
@@ -6,11 +9,11 @@ import (
 )
 
 var _ = Describe("Byohost Installer Tests", func() {
-	 Context("When installer is created", func() {
-                It("Should return error", func() {
+	Context("When installer is created", func() {
+		It("Should return error", func() {
 			_, err := New("repo", "downloadPath", nil)
 			Expect(err).ShouldNot((HaveOccurred()))
-                })
+		})
 	})
 
 })


### PR DESCRIPTION
All files should contain the license and permission headers
This linter check will allow to flag errors whenever these headers are
not present