### PR TITLE
Set the right image name in Make build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,14 +132,14 @@ uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified 
 	$(KUSTOMIZE) build config/crd | kubectl delete -f -
 
 deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/caph-manager=${IMG}
 	$(KUSTOMIZE) build config/default | kubectl apply -f -
 
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
 publish-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
+	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/caph-manager=${IMG}
 	$(KUSTOMIZE) build config/default > infrastructure-components.yaml
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen


### PR DESCRIPTION
we currently use gcr.io/k8s-staging-cluster-api/caph-manager as the
default image name in the yaml, so the make sub command need to update
accordingly.

Signed-off-by: Yixing Jia <yixingj@vmware.com>