### PR TITLE
Registered Events to k8s Event API for ByoMachine, ByoHost

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -143,6 +143,7 @@ func main() {
 				DefaultNetworkInterfaceName: registration.LocalHostRegistrar.ByoHostInfo.DefaultNetworkInterfaceName,
 			},
 		},
+		Recorder: mgr.GetEventRecorderFor("hostagent-controller"),
 	}
 	if err = hostReconciler.SetupWithManager(context.TODO(), mgr); err != nil {
 		klog.Errorf("unable to create controller, err=%v", err)

--- a/common/testutils.go
+++ b/common/testutils.go
@@ -1,0 +1,34 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package common
+
+// CollectEvents returns a slice of string consisting
+// all the events from the record.FakeRecorder.Events Chan
+func CollectEvents(source <-chan string) []string {
+	done := false
+	events := make([]string, 0)
+	for !done {
+		select {
+		case event := <-source:
+			events = append(events, event)
+		default:
+			done = true
+		}
+	}
+	return events
+}
+
+// DrainEvents clears all the events in the chan recorder.Events
+// This is a hack as the current byomachine reconciler is global to test
+// and the record.FakeRecorder could have events from different tests
+// It could also introduce data races in parallel tests run
+func DrainEvents(events chan string) {
+	for {
+		select {
+		case <-events:
+		default:
+			return
+		}
+	}
+}

--- a/controllers/infrastructure/suite_test.go
+++ b/controllers/infrastructure/suite_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -38,6 +39,7 @@ var (
 	testEnv               *envtest.Environment
 	clientFake            client.Client
 	reconciler            *ByoMachineReconciler
+	recorder              *record.FakeRecorder
 	capiCluster           *clusterv1.Cluster
 	defaultClusterName    string = "my-cluster"
 	defaultNodeName       string = "my-host"
@@ -102,9 +104,11 @@ var _ = BeforeSuite(func() {
 		node,
 	).Build()
 
+	recorder = record.NewFakeRecorder(32)
 	reconciler = &ByoMachineReconciler{
-		Client:  k8sManager.GetClient(),
-		Tracker: remote.NewTestClusterCacheTracker(logf.NullLogger{}, clientFake, scheme.Scheme, client.ObjectKey{Name: capiCluster.Name, Namespace: capiCluster.Namespace}),
+		Client:   k8sManager.GetClient(),
+		Tracker:  remote.NewTestClusterCacheTracker(logf.NullLogger{}, clientFake, scheme.Scheme, client.ObjectKey{Name: capiCluster.Name, Namespace: capiCluster.Namespace}),
+		Recorder: recorder,
 	}
 	err = reconciler.SetupWithManager(context.TODO(), k8sManager)
 	Expect(err).NotTo(HaveOccurred())

--- a/main.go
+++ b/main.go
@@ -87,9 +87,10 @@ func main() {
 	}
 
 	if err = (&byohcontrollers.ByoMachineReconciler{
-		Client:  mgr.GetClient(),
-		Scheme:  mgr.GetScheme(),
-		Tracker: tracker,
+		Client:   mgr.GetClient(),
+		Scheme:   mgr.GetScheme(),
+		Tracker:  tracker,
+		Recorder: mgr.GetEventRecorderFor("byomachine-controller"),
 	}).SetupWithManager(context.TODO(), mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "ByoMachine")
 		os.Exit(1)


### PR DESCRIPTION
Important events are registered to k8s events API and can be viewed on `ByoHost` and `ByoMachine` CR using `kubectl describe`. Necessary tests are added. testutils is introduced again to keep `CollectEvents` and `DrainEvents` methods.

Events for ByoHost CR
- Warning ReadBootstrapSecretFailed
- Warning InstallK8sComponentFailed
- Warning BootstrapK8sNodeFailed
- Warning ResetK8sNodeFailed
- Normal BootstrapK8sNodeSucceeded
- Normal ResetK8sNodeSucceeded
- Normal k8sComponentInstalled
- Normal ByoHostAttachSucceeded
- Normal ByoHostReleaseSucceeded

Events for ByoMachine CR
- Warning SetNodeProviderFailed
- Warning ByoHostSelectionFailed
- Normal ByoHostReleaseSucceeded
- Normal ByoHostAttachSucceeded
- Normal NodeProvisionedSucceeded

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>