### PR TITLE
Ubuntu 20.04 installer

### DIFF
--- a/agent/installer/internal/algo/algo_suite_test.go
+++ b/agent/installer/internal/algo/algo_suite_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 import (

--- a/agent/installer/internal/algo/algo_test.go
+++ b/agent/installer/internal/algo/algo_test.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 import (

--- a/agent/installer/internal/algo/apt_step.go
+++ b/agent/installer/internal/algo/apt_step.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 import (

--- a/agent/installer/internal/algo/installer.go
+++ b/agent/installer/internal/algo/installer.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 // This is a generic installer interface

--- a/agent/installer/internal/algo/output_builder.go
+++ b/agent/installer/internal/algo/output_builder.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 type OutputBuilder interface {

--- a/agent/installer/internal/algo/shell_step.go
+++ b/agent/installer/internal/algo/shell_step.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 import (

--- a/agent/installer/internal/algo/ubuntu20_4K8s1_22.go
+++ b/agent/installer/internal/algo/ubuntu20_4K8s1_22.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package algo
 
 import (


### PR DESCRIPTION
implemented the installer algo business logic and a version for Ubuntu 20.04

Please note that the discussion history has been lost due to the deprecation of the original main that the initial PR has been made on. 
To access the discussion and all comments of related to the commits follow this link: https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/pull/90