### PR TITLE
Refactor testutils to move event helpers to a separate package

### DIFF
--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -12,8 +12,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit/cloudinitfakes"
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1beta1"
-	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/test/builder"
+	eventutils "github.com/vmware-tanzu/cluster-api-provider-byoh/test/utils/events"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -139,7 +139,7 @@ var _ = Describe("Byohost Agent Tests", func() {
 				Expect(reconcilerErr).To(MatchError("secrets \"non-existent\" not found"))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					fmt.Sprintf("Warning ReadBootstrapSecretFailed bootstrap secret %s not found", byoHost.Spec.BootstrapSecret.Name),
 				}))
@@ -190,7 +190,7 @@ runCmd:
 					}))
 
 					// assert events
-					events := common.CollectEvents(recorder.Events)
+					events := eventutils.CollectEvents(recorder.Events)
 					Expect(events).Should(ConsistOf([]string{
 						"Normal k8sComponentInstalled Successfully Installed K8s components",
 						"Warning BootstrapK8sNodeFailed k8s Node Bootstrap failed",
@@ -220,7 +220,7 @@ runCmd:
 					}))
 
 					// assert events
-					events := common.CollectEvents(recorder.Events)
+					events := eventutils.CollectEvents(recorder.Events)
 					Expect(events).Should(ConsistOf([]string{
 						"Normal k8sComponentInstalled Successfully Installed K8s components",
 						"Normal BootstrapK8sNodeSucceeded k8s Node Bootstraped",
@@ -300,7 +300,7 @@ runCmd:
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					"Normal ResetK8sNodeSucceeded k8s Node Reset completed",
 				}))
@@ -326,7 +326,7 @@ runCmd:
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					"Warning ResetK8sNodeFailed k8s Node Reset failed",
 				}))

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -11,8 +11,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-byoh/apis/infrastructure/v1beta1"
-	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
+
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/test/builder"
+	eventutils "github.com/vmware-tanzu/cluster-api-provider-byoh/test/utils/events"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -61,7 +62,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 	})
 
 	AfterEach(func() {
-		common.DrainEvents(recorder.Events)
+		eventutils.DrainEvents(recorder.Events)
 	})
 
 	It("should ignore byomachine if it is not found", func() {
@@ -133,7 +134,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					"Warning ByoHostSelectionFailed No available ByoHost",
 				}))
@@ -198,7 +199,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					fmt.Sprintf("Normal ByoHostAttachSucceeded Attached to ByoMachine %s", createdByoMachine.Name),
 					fmt.Sprintf("Normal NodeProvisionedSucceeded Provisioned Node %s", createdByoHost.Name),
@@ -262,7 +263,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 						Expect(err).NotTo(HaveOccurred())
 
 						// assert events
-						events := common.CollectEvents(recorder.Events)
+						events := eventutils.CollectEvents(recorder.Events)
 						Expect(events).Should(ConsistOf([]string{
 							fmt.Sprintf("Normal ByoHostReleaseSucceeded Released ByoHost %s", byoHost.Name),
 							fmt.Sprintf("Normal ByoHostReleaseSucceeded ByoHost Released by %s", deletedByoMachine.Name),
@@ -414,7 +415,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					"Warning ByoHostSelectionFailed No available ByoHost",
 				}))
@@ -452,7 +453,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(events).Should(ConsistOf([]string{
 					"Warning ByoHostSelectionFailed No available ByoHost",
 				}))
@@ -494,7 +495,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(len(events)).Should(Equal(3))
 
 				node1 := corev1.Node{}
@@ -543,7 +544,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				}))
 
 				// assert events
-				events := common.CollectEvents(recorder.Events)
+				events := eventutils.CollectEvents(recorder.Events)
 				Expect(len(events)).Should(Equal(3))
 
 				node := corev1.Node{}
@@ -590,7 +591,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 			}))
 
 			// assert events
-			events := common.CollectEvents(recorder.Events)
+			events := eventutils.CollectEvents(recorder.Events)
 			Expect(len(events)).Should(Equal(0))
 		})
 	})

--- a/test/utils/events/testutils.go
+++ b/test/utils/events/testutils.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-package common
+package events
 
 // CollectEvents returns a slice of string consisting
 // all the events from the record.FakeRecorder.Events Chan


### PR DESCRIPTION
Event helper methods in the `common` package are moved out to a separate package `events`. 

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
Package names such as `utils` or `common` are not aligned with the `Go` guidelines which suggests package names should be short, concise, evocative.

Source:
- https://dave.cheney.net/2019/01/08/avoid-package-names-like-base-util-or-common
- https://golang.org/doc/effective_go#package-names

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->