### PR TITLE
🐛 Fix to handle ByoHostRelease Succeeded Events

### DIFF
--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -179,10 +179,10 @@ func (r *ByoMachineReconciler) reconcileDelete(ctx context.Context, machineScope
 		if err := r.markHostForCleanup(ctx, machineScope); err != nil {
 			return ctrl.Result{}, err
 		}
+		r.Recorder.Eventf(machineScope.ByoHost, corev1.EventTypeNormal, "ByoHostReleaseSucceeded", "ByoHost Released by %s", machineScope.ByoMachine.Name)
+		r.Recorder.Eventf(machineScope.ByoMachine, corev1.EventTypeNormal, "ByoHostReleaseSucceeded", "Released ByoHost %s", machineScope.ByoHost.Name)
 	}
 
-	r.Recorder.Eventf(machineScope.ByoHost, corev1.EventTypeNormal, "ByoHostReleaseSucceeded", "ByoHost Released by %s", machineScope.ByoMachine.Name)
-	r.Recorder.Eventf(machineScope.ByoMachine, corev1.EventTypeNormal, "ByoHostReleaseSucceeded", "Released ByoHost %s", machineScope.ByoHost.Name)
 	controllerutil.RemoveFinalizer(machineScope.ByoMachine, infrav1.MachineFinalizer)
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
The `ByoHostReleaseSucceeded` Events will be only registered when there is a Byohost attached to ByoMachine
Added integration test for this scenario

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->