### PR TITLE
Add new make targets to generate release assets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -143,7 +143,10 @@ deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in
 undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config.
 	$(KUSTOMIZE) build config/default | kubectl delete -f -
 
-publish-cluster-templates: cluster-templates
+$(RELEASE_DIR):
+	mkdir -p $(RELEASE_DIR)
+
+publish-cluster-templates: $(RELEASE_DIR) cluster-templates
 	cp $(BYOH_TEMPLATES)/v1beta1/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
 
 publish-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,6 @@ TAG ?= dev
 RELEASE_DIR := out
 
 # Define registries
-RELEASE_REGISTRY := projects.registry.mware.com/cluster_api_provider_bringyourownhost
-RELEASE_CONTROLLER_IMG := $(RELEASE_REGISTRY)/$(IMAGE_NAME)
 STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api
 
 # Image URL to use all building/pushing image targets

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,6 +5,12 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- name: manager-config
-  files:
+- files:
   - controller_manager_config.yaml
+  name: manager-config
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+- name: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller
+  newName: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller
+  newTag: dev

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,12 +5,6 @@ generatorOptions:
   disableNameSuffixHash: true
 
 configMapGenerator:
-- files:
+- name: manager-config
+  files:
   - controller_manager_config.yaml
-  name: manager-config
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-images:
-- name: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller
-  newName: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller
-  newTag: dev


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is needed to automate our release process. Defining make targets that will be used by the release workflow. Added targets for
- host-agent-binary
- infrastructure-components
- cluster-template
- metadata.yaml

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
partially fixes #180 

