### PR TITLE
According to team input include byoh-bundle in the bundle name.

### DIFF
--- a/agent/installer/bundle_downloader.go
+++ b/agent/installer/bundle_downloader.go
@@ -112,7 +112,7 @@ func (bd *bundleDownloader) GetBundleDirPath(k8sVersion string) string {
 
 // GetBundleName returns the name of the bundle in normalized format.
 func GetBundleName(normalizedOsVersion, k8sVersion string) string {
-	return strings.ToLower(fmt.Sprintf("%s_k8s_%s", normalizedOsVersion, k8sVersion))
+	return strings.ToLower(fmt.Sprintf("byoh-bundle-%s_k8s_%s", normalizedOsVersion, k8sVersion))
 }
 
 // getBundleAddr returns the exact address to the bundle in the repo.

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -36,7 +36,7 @@ func getSupportedRegistry(bd *bundleDownloader, ob algo.OutputBuilder) registry 
 		k8s  string
 		algo algo.K8sStepProvider
 	}{
-		{"Ubuntu_20.04.1_x86-64", "1_22", &algo.Ubuntu20_4K8s1_22{}},
+		{"Ubuntu_20.04.1_x86-64", "v1.22.1", &algo.Ubuntu20_4K8s1_22{}},
 		/*
 		 * ADD HERE to add support for new os or k8s
 		 * You may map new versions to old classes if they do the job


### PR DESCRIPTION
Include byoh-bundle in the bundle name.

Follow team's feedback.

Example:
For an OS detected as 'Ubuntu_20.04.1_x86-64' (by installer) and supplied k8sVer (to installer) as 'v1.22.1' installer will expect
the bundle name to be 'byoh-bundle-ubuntu_20.04.1_x86-64_k8s_v1.22.1'

For expected bundle names, refer to the installer cli