### PR TITLE
clean the /et/cni/net.d folder before we start the k8s provsion

### DIFF
--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -35,7 +35,7 @@ jobs:
         run: sudo apt-get install golang-ginkgo-dev
 
       - name: make sure it has permission to clean up directory
-        run: sudo chmod -R 777 /etc
+        run: sudo chmod -R 755 /etc
 
       - name: test agent
         run: make agent-test

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -34,5 +34,8 @@ jobs:
       - name: Install ginkgo
         run: sudo apt-get install golang-ginkgo-dev
 
+      - name: make sure it has permission to clean up directory
+        run: sudo chmod -R 777 /etc
+
       - name: test agent
         run: make agent-test

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -111,6 +111,8 @@ func (r *HostReconciler) reconcileNormal(ctx context.Context, byoHost *infrastru
 		err = r.cleank8sdirectories(ctx)
 		if err != nil {
 			logger.Error(err, "error cleaning up k8s directories, please delete it manually for reconcile to proceed.")
+			r.Recorder.Event(byoHost, corev1.EventTypeWarning, "CleanK8sDirectoriesFailed", "clean k8s directories failed")
+			conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.CleanK8sDirectoriesFailedReason, clusterv1.ConditionSeverityError, "")
 			return ctrl.Result{}, err
 		}
 

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -110,7 +110,7 @@ func (r *HostReconciler) reconcileNormal(ctx context.Context, byoHost *infrastru
 
 		err = r.cleank8sdirectories(ctx)
 		if err != nil {
-			logger.Error(err, "error cleaning up cleank8sdirectories directory, please delete it manually for reconcile to proceed.")
+			logger.Error(err, "error cleaning up k8s directories, please delete it manually for reconcile to proceed.")
 			return ctrl.Result{}, err
 		}
 

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/cloudinit"
 	"github.com/vmware-tanzu/cluster-api-provider-byoh/agent/registration"
+	"github.com/vmware-tanzu/cluster-api-provider-byoh/common"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -159,14 +160,14 @@ func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	dirs := []string{
-		"/run/kubeadm",
-		"/etc/cni/net.d",
+		"/run/kubeadm/*",
+		"/etc/cni/net.d/*",
 	}
 
 	errList := []error{}
 	for _, dir := range dirs {
 		logger.Info(fmt.Sprintf("cleaning up directory %s", dir))
-		if err := os.RemoveAll(dir); err != nil {
+		if err := common.RemoveGlob(dir); err != nil {
 			logger.Error(err, fmt.Sprintf("failed to clean up directory %s", dir))
 			errList = append(errList, err)
 		}

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -152,13 +152,13 @@ func (r *HostReconciler) SetupWithManager(ctx context.Context, mgr manager.Manag
 		Complete(r)
 }
 
-// cleanup /run/kubeadm, /et/cni/net.d dirs to remove any stale config on the host
+// cleanup /run/kubeadm, /etc/cni/net.d dirs to remove any stale config on the host
 func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
 
 	dirs := []string{
 		"/run/kubeadm",
-		"/et/cni/net.d",
+		"/etc/cni/net.d",
 	}
 
 	errList := []error{}

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -152,7 +152,7 @@ func (r *HostReconciler) SetupWithManager(ctx context.Context, mgr manager.Manag
 		Complete(r)
 }
 
-// cleanup some dirs to remove any stale config on the host
+// cleanup /run/kubeadm, /et/cni/net.d dirs to remove any stale config on the host
 func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	logger := ctrl.LoggerFrom(ctx)
 

--- a/apis/infrastructure/v1beta1/condition_consts.go
+++ b/apis/infrastructure/v1beta1/condition_consts.go
@@ -26,7 +26,9 @@ const (
 	// This secret is available on byohost.Spec.BootstrapSecret field
 	BootstrapDataSecretUnavailableReason = "BootstrapDataSecretUnavailable"
 
-	// CleanK8sDirectoriesFailedReason indicates that clean k8s directories failed for some reason
+	// CleanK8sDirectoriesFailedReason indicates that clean k8s directories failed for some reason, please
+	// delete it manually for reconcile to proceed.
+	// The cleaned directories are /run/kubeadm and /etc/cni/net.d
 	CleanK8sDirectoriesFailedReason = "CleanK8sDirectoriesFailed"
 
 	// CloudInitExecutionFailedReason indicates that cloudinit failed to parse and execute the directives

--- a/apis/infrastructure/v1beta1/condition_consts.go
+++ b/apis/infrastructure/v1beta1/condition_consts.go
@@ -26,6 +26,9 @@ const (
 	// This secret is available on byohost.Spec.BootstrapSecret field
 	BootstrapDataSecretUnavailableReason = "BootstrapDataSecretUnavailable"
 
+	// CleanK8sDirectoriesFailedReason indicates that clean k8s directories failed for some reason
+	CleanK8sDirectoriesFailedReason = "CleanK8sDirectoriesFailed"
+
 	// CloudInitExecutionFailedReason indicates that cloudinit failed to parse and execute the directives
 	// that are part of the cloud-config file
 	CloudInitExecutionFailedReason = "CloudInitExecutionFailed"

--- a/common/utils.go
+++ b/common/utils.go
@@ -8,6 +8,8 @@ import (
 	"compress/gzip"
 	"io"
 	"math/rand"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -62,4 +64,18 @@ func GunzipData(data []byte) ([]byte, error) {
 	}
 
 	return resB.Bytes(), nil
+}
+
+func RemoveGlob(path string) error {
+	contents, err := filepath.Glob(path)
+	if err != nil {
+		return err
+	}
+	for _, item := range contents {
+		err = os.RemoveAll(item)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
we should clean the /et/cni/net.d folder before we start the k8s provsion. It will save us from a lot of potential network issues, especially we try to re-use a byoh host.