### PR TITLE
Remove the hardcoding for ControlPlaneEndpoint in Cluster Template

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ prepare-byoh-docker-host-image:
 	docker build test/e2e -f test/e2e/BYOHDockerFile -t ${BYOH_BASE_IMG}
 
 test-e2e: docker-build prepare-byoh-docker-host-image $(GINKGO) cluster-templates ## Run the end-to-end tests
-	$(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \
+	CONTROL_PLANE_ENDPOINT_IP=172.18.10.151 $(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \
 	    -e2e.config="$(E2E_CONF_FILE)" \
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -134,7 +134,7 @@ export NAMESPACE="default"
 export KUBERNETES_VERSION="v1.22.0"
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
-export CONTROL_PLANE_ENDPOINT=<static IP from the subnet where the containers are running>
+export CONTROL_PLANE_ENDPOINT_IP=<static IP from the subnet where the containers are running>
 ```
 
 From ```cluster-api-provider-bringyourownhost``` folder

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template-byoh.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template-byoh.yaml
@@ -82,7 +82,7 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_address
-              value: ${CONTROL_PLANE_ENDPOINT}
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
             - name: vip_interface
               value: {{ .DefaultNetworkInterfaceName }}
             - name: vip_leaseduration

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml
@@ -119,7 +119,7 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_address
-              value: 172.18.10.10
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
             - name: vip_interface
               value: {{ .DefaultNetworkInterfaceName }}
             - name: vip_leaseduration
@@ -184,7 +184,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
-    host: 172.18.10.10
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-with-kcp.yaml
@@ -28,7 +28,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   controlPlaneEndpoint:
-    host: 172.18.10.10
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
@@ -77,7 +77,7 @@ spec:
             - name: vip_leaderelection
               value: "true"
             - name: vip_address
-              value: 172.18.10.10
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
             - name: vip_interface
               value: {{ .DefaultNetworkInterfaceName }}
             - name: vip_leaseduration


### PR DESCRIPTION
Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
This PR removes the hardcoding of control plane endpoint IP from the `cluster-template` yamls. For `e2e` tests we are substituting the same using env variables.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #197 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->