### PR TITLE
Add support for bundle registry and tag fields

### DIFF
--- a/apis/infrastructure/v1beta1/byocluster_types.go
+++ b/apis/infrastructure/v1beta1/byocluster_types.go
@@ -20,6 +20,14 @@ type ByoClusterSpec struct {
 	// ControlPlaneEndpoint represents the endpoint used to communicate with the control plane.
 	// +optional
 	ControlPlaneEndpoint APIEndpoint `json:"controlPlaneEndpoint"`
+
+	// BundleLookupBaseRegistry is the base Registry URL that is used for pulling byoh bundle images,
+	// if not set, the default will be set to https://projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+	// +optional
+	BundleLookupBaseRegistry string `json:"bundleLookupBaseRegistry,omitempty"`
+
+	// BundleLookupTag is the tag of the BYOH bundle to be used
+	BundleLookupTag string `json:"bundleLookupTag,omitempty"`
 }
 
 // ByoClusterStatus defines the observed state of ByoCluster

--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -10,10 +10,12 @@ import (
 )
 
 const (
-	HostCleanupAnnotation   = "byoh.infrastructure.cluster.x-k8s.io/unregistering"
-	EndPointIPAnnotation    = "byoh.infrastructure.cluster.x-k8s.io/endpointip"
-	K8sVersionAnnotation    = "byoh.infrastructure.cluster.x-k8s.io/k8sversion"
-	AttachedByoMachineLabel = "byoh.infrastructure.cluster.x-k8s.io/byomachine-name"
+	HostCleanupAnnotation              = "byoh.infrastructure.cluster.x-k8s.io/unregistering"
+	EndPointIPAnnotation               = "byoh.infrastructure.cluster.x-k8s.io/endpointip"
+	K8sVersionAnnotation               = "byoh.infrastructure.cluster.x-k8s.io/k8sversion"
+	AttachedByoMachineLabel            = "byoh.infrastructure.cluster.x-k8s.io/byomachine-name"
+	BundleLookupBaseRegistryAnnotation = "byoh.infrastructure.cluster.x-k8s.io/bundle-registry"
+	BundleLookupTagAnnotation          = "byoh.infrastructure.cluster.x-k8s.io/bundle-tag"
 )
 
 // ByoHostSpec defines the desired state of ByoHost

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byoclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byoclusters.yaml
@@ -38,6 +38,14 @@ spec:
           spec:
             description: ByoClusterSpec defines the desired state of ByoCluster
             properties:
+              bundleLookupBaseRegistry:
+                description: BundleLookupBaseRegistry is the base Registry URL that
+                  is used for pulling byoh bundle images, if not set, the default
+                  will be set to https://projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+                type: string
+              bundleLookupTag:
+                description: BundleLookupTag is the tag of the BYOH bundle to be used
+                type: string
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint used to
                   communicate with the control plane.

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -73,7 +73,7 @@ type ByoMachineReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 
 // Reconcile handles ByoMachine events
-// nolint: gocyclo
+// nolint: gocyclo, funlen
 func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconcile request received")
@@ -114,13 +114,12 @@ func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	logger = logger.WithValues("cluster", cluster.Name)
 
 	byoCluster := &infrav1.ByoCluster{}
-
 	infraClusterName := client.ObjectKey{
 		Namespace: byoMachine.Namespace,
 		Name:      cluster.Spec.InfrastructureRef.Name,
 	}
 
-	if err := r.Client.Get(ctx, infraClusterName, byoCluster); err != nil {
+	if err = r.Client.Get(ctx, infraClusterName, byoCluster); err != nil {
 		logger.Error(err, "failed to get infra cluster")
 		return ctrl.Result{}, nil
 	}

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -112,6 +112,19 @@ func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, nil
 	}
 	logger = logger.WithValues("cluster", cluster.Name)
+
+	byoCluster := &infrav1.ByoCluster{}
+
+	infraClusterName := client.ObjectKey{
+		Namespace: byoMachine.Namespace,
+		Name:      cluster.Spec.InfrastructureRef.Name,
+	}
+
+	if err := r.Client.Get(ctx, infraClusterName, byoCluster); err != nil {
+		logger.Error(err, "failed to get infra cluster")
+		return ctrl.Result{}, nil
+	}
+
 	helper, _ := patch.NewHelper(byoMachine, r.Client)
 	defer func() {
 		if err = helper.Patch(ctx, byoMachine); err != nil && reterr == nil {
@@ -134,6 +147,7 @@ func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		Client:     r.Client,
 		Cluster:    cluster,
 		Machine:    machine,
+		ByoCluster: byoCluster,
 		ByoMachine: byoMachine,
 		ByoHost:    refByoHost,
 	})
@@ -452,6 +466,8 @@ func (r *ByoMachineReconciler) attachByoHost(ctx context.Context, machineScope *
 	}
 	host.Annotations[infrav1.EndPointIPAnnotation] = machineScope.Cluster.Spec.ControlPlaneEndpoint.Host
 	host.Annotations[infrav1.K8sVersionAnnotation] = *machineScope.Machine.Spec.Version
+	host.Annotations[infrav1.BundleLookupBaseRegistryAnnotation] = machineScope.ByoCluster.Spec.BundleLookupBaseRegistry
+	host.Annotations[infrav1.BundleLookupTagAnnotation] = machineScope.ByoCluster.Spec.BundleLookupTag
 
 	err = byohostHelper.Patch(ctx, &host)
 	if err != nil {

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -207,7 +207,10 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				// Assert annotations on byohost
 				testClusterVersion := "1.22"
 				createdByoHostAnnotations := createdByoHost.GetAnnotations()
+
 				Expect(createdByoHostAnnotations[infrastructurev1beta1.K8sVersionAnnotation]).To(Equal(testClusterVersion))
+				Expect(createdByoHostAnnotations[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation]).To(Equal(byoCluster.Spec.BundleLookupBaseRegistry))
+				Expect(createdByoHostAnnotations[infrastructurev1beta1.BundleLookupTagAnnotation]).To(Equal(byoCluster.Spec.BundleLookupTag))
 
 				createdByoMachine := &infrastructurev1beta1.ByoMachine{}
 				err = k8sClientUncached.Get(ctx, byoMachineLookupKey, createdByoMachine)
@@ -337,6 +340,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 			It("should mark BYOHostReady as False when cluster is paused", func() {
 				pausedCluster := builder.Cluster(defaultNamespace, "paused-cluster").
 					WithPausedField(true).
+					WithInfrastructureRef(byoCluster).
 					Build()
 				Expect(k8sClientUncached.Create(ctx, pausedCluster)).Should(Succeed())
 

--- a/controllers/infrastructure/byomachine_scope.go
+++ b/controllers/infrastructure/byomachine_scope.go
@@ -16,6 +16,7 @@ type byoMachineScopeParams struct {
 	Client     client.Client
 	Cluster    *clusterv1.Cluster
 	Machine    *clusterv1.Machine
+	ByoCluster *infrav1.ByoCluster
 	ByoMachine *infrav1.ByoMachine
 	ByoHost    *infrav1.ByoHost
 }
@@ -26,6 +27,7 @@ type byoMachineScope struct {
 	patchHelper *patch.Helper
 	Cluster     *clusterv1.Cluster
 	Machine     *clusterv1.Machine
+	ByoCluster  *infrav1.ByoCluster
 	ByoMachine  *infrav1.ByoMachine
 	ByoHost     *infrav1.ByoHost
 }
@@ -45,6 +47,9 @@ func newByoMachineScope(params byoMachineScopeParams) (*byoMachineScope, error) 
 	if params.ByoMachine == nil {
 		return nil, errors.New("BYOMachine is required when creating a MachineScope")
 	}
+	if params.ByoCluster == nil {
+		return nil, errors.New("ByoCluster is required when creating a MachineScope")
+	}
 
 	helper, err := patch.NewHelper(params.ByoMachine, params.Client)
 	if err != nil {
@@ -56,6 +61,7 @@ func newByoMachineScope(params byoMachineScopeParams) (*byoMachineScope, error) 
 		patchHelper: helper,
 		Cluster:     params.Cluster,
 		Machine:     params.Machine,
+		ByoCluster:  params.ByoCluster,
 		ByoMachine:  params.ByoMachine,
 		ByoHost:     params.ByoHost,
 	}, nil


### PR DESCRIPTION

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
- introduce bundleRegistry and bundleTag fields on ByoCluster spec
- add annotations on host for registry and tag
- unit tests for the byomachine controller

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #203 
