### PR TITLE
Installer OS mapping

### DIFF
--- a/agent/installer/cli.go
+++ b/agent/installer/cli.go
@@ -69,7 +69,6 @@ func Main() {
 
 func listSupported() {
 	w := new(tabwriter.Writer)
-	// minwidth, tabwidth, padding, padchar, flags
 	const (
 		minwidth = 8
 		tabwidth = 8

--- a/agent/installer/cli.go
+++ b/agent/installer/cli.go
@@ -6,10 +6,10 @@ package installer
 import (
 	"flag"
 	"fmt"
-	"os"
-	"text/tabwriter"
 	"github.com/go-logr/logr"
 	"k8s.io/klog/klogr"
+	"os"
+	"text/tabwriter"
 )
 
 var (
@@ -70,36 +70,35 @@ func Main() {
 func listSupported() {
 	w := new(tabwriter.Writer)
 	// minwidth, tabwidth, padding, padchar, flags
-	w.Init(os.Stdout, 8, 8, 0, '\t', 0)
+	const (
+		minwidth = 8
+		tabwidth = 8
+		padding  = 0
+		flags    = 0
+	)
+	w.Init(os.Stdout, minwidth, tabwidth, padding, '\t', flags)
 	defer w.Flush()
 
-	fmt.Fprintf(w, "%s\t%s\t%s\n", "OS",  "K8S Version", "BYOH Bundle Name")
+	fmt.Fprintf(w, "%s\t%s\t%s\n", "OS", "K8S Version", "BYOH Bundle Name")
 	fmt.Fprintf(w, "%s\t%s\t%s\n", "---", "-----------", "----------------")
 
-	osList, aliasMap := ListSupportedOS()
-
-	for _, os := range osList {
-		for _, k8s := range ListSupportedK8s(os) {
-			fmt.Fprintf(w, "%s\t %s\t%s\n", os, k8s, GetBundleName(os, k8s))
+	osFilters, osBundles := ListSupportedOS()
+	for i := range osFilters {
+		for _, k8s := range ListSupportedK8s(osBundles[i]) {
+			fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i], k8s))
 		}
-	}
-
-	for a, o := range aliasMap {
-		for _, k8s := range ListSupportedK8s(o) {
-                        fmt.Fprintf(w, "%s\t %s\t%s\n", a, k8s, GetBundleName(o, k8s))
-                }
 	}
 }
 
 func detectOS() {
 	osd := osDetector{}
-	os, err := osd.Detect()
+	detectedOs, err := osd.Detect()
 	if err != nil {
 		klogger.Error(err, "Error detecting OS")
 		return
 	}
 
-	fmt.Printf("Detected OS as: %s", os)
+	fmt.Printf("Detected OS as: %s", detectedOs)
 }
 
 func runInstaller(install bool) {

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -33,33 +33,37 @@ type installer struct {
 
 // getSupportedRegistry returns a registry with installers for the supported OS and K8s
 func getSupportedRegistry(bd *bundleDownloader, ob algo.OutputBuilder) registry {
-	var supportedOsK8s = []struct {
-		os   string
-		k8s  string
-		algo algo.K8sStepProvider
-		osFilter string
-	}{
-		// Ubuntu support
-		{os: "Ubuntu_20.04.1_x86-64", k8s: "v1.22.1", algo: &algo.Ubuntu20_4K8s1_22{}},
-		// Ubuntu Same-As Map. Any Ubuntu that matches osFilter is treated like os
-		{osFilter: "Ubuntu_20.04.*_x86-64", os: "Ubuntu_20.04.1_x86-64"},
+	reg := newRegistry()
+
+	addBundleInstaller := func(osBundle, k8sBundle string, stepProvider algo.K8sStepProvider) {
+		a := algo.BaseK8sInstaller{
+			K8sStepProvider: stepProvider,
+			/* BundlePath: will be set when tag is known */
+			OutputBuilder: ob}
+
+		reg.AddBundleInstaller(osBundle, k8sBundle, &a)
+	}
+
+	{
+		// Ubuntu
+
+		// BYOH Bundle Repository. Associate bundle with installer
+		linuxDistro := "Ubuntu_20.04.1_x86-64"
+		addBundleInstaller(linuxDistro, "v1.22.1", &algo.Ubuntu20_4K8s1_22{})
 		/*
-		 * ADD HERE to add support for new os or k8s
+		 * PLACEHOLDER - ADD MORE K8S VERSIONS HERE
+		 */
+
+		// Match os versions to repository os version
+		reg.AddOsFilter("Ubuntu_20.04.*_x86-64", linuxDistro)
+		/*
+		 * PLACEHOLDER - POINT MORE DISTRO VERSIONS TO THE SAME BUNDLE AND INSTALLER HERE
 		 */
 	}
 
-	reg := NewRegistry()
-	for _, t := range supportedOsK8s {
-		if t.osFilter == "" {
-			a := &algo.BaseK8sInstaller{
-                        K8sStepProvider: t.algo,
-                        /*BundlePath: will be set when tag is known */
-                        OutputBuilder: ob}
-	                reg.Add(t.os, t.k8s, a)
-		} else {
-			reg.AddOSAlias(t.osFilter, t.os)
-		}
-	}
+	/*
+	 * PLACEHOLDER - ADD MORE OS HERE
+	 */
 
 	return reg
 }
@@ -170,7 +174,7 @@ func (i *installer) getAlgoInstallerWithBundle(k8sVer, tag string) (osk8sInstall
 }
 
 // ListSupportedOS() returns the list of all supported OS-es. Can be invoked on a non-supported OS.
-func ListSupportedOS() ([]string, map[string]string) {
+func ListSupportedOS() (osFilters, osBundles []string) {
 	srd := getSupportedRegistryDescription()
 	return srd.ListOS()
 }

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -54,10 +54,10 @@ func getSupportedRegistry(bd *bundleDownloader, ob algo.OutputBuilder) registry 
 		 * PLACEHOLDER - ADD MORE K8S VERSIONS HERE
 		 */
 
-		// Match os versions to repository os version
+		// Match concrete os version to repository os version
 		reg.AddOsFilter("Ubuntu_20.04.*_x86-64", linuxDistro)
 		/*
-		 * PLACEHOLDER - POINT MORE DISTRO VERSIONS TO THE SAME BUNDLE AND INSTALLER HERE
+		 * PLACEHOLDER - POINT MORE DISTRO VERSIONS
 		 */
 	}
 

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -33,7 +33,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When installer is created", func() {
 		It("Install/uninstall should return error for unsupported k8s", func() {
-			for _, os := range ListSupportedOS() {
+			osList,_ := ListSupportedOS()
+			for _, os := range osList {
 				i := NewPreviewInstaller(os, nil)
 
 				err := i.Install("unsupported-k8s", testTag)
@@ -46,7 +47,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When installer is created", func() {
 		It("Install/uninstall should call only the output builder", func() {
-			for _, os := range ListSupportedOS() {
+			osList,_ := ListSupportedOS()
+                        for _, os := range osList {
 				for _, k8s := range ListSupportedK8s(os) {
 					{
 						ob := algo.OutputBuilderCounter{}
@@ -69,19 +71,22 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When ListSupportedOS is called", func() {
 		It("Should return non-empty result", func() {
-			Expect(ListSupportedOS()).ShouldNot(BeEmpty())
+			osList,_ := ListSupportedOS()
+			Expect(osList).ShouldNot(BeEmpty())
 		})
 	})
 	Context("When ListSupportedK8s is called for all supported OSes", func() {
 		It("Should return non-empty result", func() {
-			for _, os := range ListSupportedOS() {
+			osList,_ := ListSupportedOS()
+                        for _, os := range osList {
 				Expect(ListSupportedK8s(os)).ShouldNot(BeEmpty())
 			}
 		})
 	})
 	Context("When PreviewChanges is called for all supported os and k8s", func() {
 		It("Should not return error", func() {
-			for _, os := range ListSupportedOS() {
+			osList,_ := ListSupportedOS()
+                        for _, os := range osList {
 				for _, k8s := range ListSupportedK8s(os) {
 					_, _, err := PreviewChanges(os, k8s)
 					Expect(err).ShouldNot((HaveOccurred()))
@@ -91,7 +96,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When PreviewChanges is called for supported os and k8s", func() {
 		It("Should return non-empty result", func() {
-			os := ListSupportedOS()[0]
+			osList,_ := ListSupportedOS()
+			os := osList[0]
 			k8s := ListSupportedK8s(os)[0]
 			install, uninstall, err := PreviewChanges(os, k8s)
 			Expect(err).ShouldNot((HaveOccurred()))

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When installer is created", func() {
 		It("Install/uninstall should return error for unsupported k8s", func() {
-			osList,_ := ListSupportedOS()
+			_, osList := ListSupportedOS()
 			for _, os := range osList {
 				i := NewPreviewInstaller(os, nil)
 
@@ -47,8 +47,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When installer is created", func() {
 		It("Install/uninstall should call only the output builder", func() {
-			osList,_ := ListSupportedOS()
-                        for _, os := range osList {
+			_, osList := ListSupportedOS()
+			for _, os := range osList {
 				for _, k8s := range ListSupportedK8s(os) {
 					{
 						ob := algo.OutputBuilderCounter{}
@@ -71,22 +71,22 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When ListSupportedOS is called", func() {
 		It("Should return non-empty result", func() {
-			osList,_ := ListSupportedOS()
+			_, osList := ListSupportedOS()
 			Expect(osList).ShouldNot(BeEmpty())
 		})
 	})
 	Context("When ListSupportedK8s is called for all supported OSes", func() {
 		It("Should return non-empty result", func() {
-			osList,_ := ListSupportedOS()
-                        for _, os := range osList {
+			_, osList := ListSupportedOS()
+			for _, os := range osList {
 				Expect(ListSupportedK8s(os)).ShouldNot(BeEmpty())
 			}
 		})
 	})
 	Context("When PreviewChanges is called for all supported os and k8s", func() {
 		It("Should not return error", func() {
-			osList,_ := ListSupportedOS()
-                        for _, os := range osList {
+			_, osList := ListSupportedOS()
+			for _, os := range osList {
 				for _, k8s := range ListSupportedK8s(os) {
 					_, _, err := PreviewChanges(os, k8s)
 					Expect(err).ShouldNot((HaveOccurred()))
@@ -96,7 +96,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 	})
 	Context("When PreviewChanges is called for supported os and k8s", func() {
 		It("Should return non-empty result", func() {
-			osList,_ := ListSupportedOS()
+			_, osList := ListSupportedOS()
 			os := osList[0]
 			k8s := ListSupportedK8s(os)[0]
 			install, uninstall, err := PreviewChanges(os, k8s)

--- a/agent/installer/registry.go
+++ b/agent/installer/registry.go
@@ -17,9 +17,9 @@ type filterBundlePair struct {
 }
 type filterBundleList []filterBundlePair
 
-// Registry associates a (OS,K8sVersion) pair with an installer:
-// 1. Add a bundle and installer
-// 2. Point os filters to them
+// Registry contains
+// 1. Entries associating BYOH Bundle i.e. (OS,K8sVersion) in the Repository with Installer in Host Agent
+// 2. Entries that match a concrete OS to a BYOH Bundle OS from the Repository
 type registry struct {
 	osk8sInstallerMap
 	filterBundleList

--- a/agent/installer/registry.go
+++ b/agent/installer/registry.go
@@ -5,19 +5,22 @@ package installer
 
 import (
 	"fmt"
+	"regexp"
 )
 
 type osk8sInstaller interface{}
 type k8sInstallerMap map[string]osk8sInstaller
 type osk8sInstallerMap map[string]k8sInstallerMap
+type aliasOSMap map[string]string
 
 // Registry associates a (OS,K8sVersion) pair with an installer
 type registry struct {
 	osk8sInstallerMap
+	aliasOSMap
 }
 
 func NewRegistry() registry {
-	return registry{make(osk8sInstallerMap)}
+	return registry{make(osk8sInstallerMap), make(aliasOSMap)}
 }
 
 func (r *registry) Add(os, k8sVer string, installer osk8sInstaller) {
@@ -32,22 +35,49 @@ func (r *registry) Add(os, k8sVer string, installer osk8sInstaller) {
 	r.osk8sInstallerMap[os][k8sVer] = installer
 }
 
-func (r *registry) ListOS() []string {
+func (r *registry) AddOSAlias(osFilter, os string) {
+	if _, alreadyExist := r.aliasOSMap[osFilter]; alreadyExist {
+                panic(fmt.Sprintf("alias %v already exists", osFilter))
+        }
+
+	r.aliasOSMap[osFilter] = os
+}
+
+func (r *registry) ListOS() ([]string, aliasOSMap) {
 	result := make([]string, 0, len(r.osk8sInstallerMap))
+
 	for os := range(r.osk8sInstallerMap) {
 		result = append(result, os)
 	}
-	return result
+
+	return result, r.aliasOSMap
 }
 
 func (r *registry) ListK8s(os string) []string {
 	result := make([]string, 0, len(r.osk8sInstallerMap[os]))
-	for k8s := range(r.osk8sInstallerMap[os]) {
+	for k8s := range(r.resolveK8sInstallerMap(os)) {
 		result = append(result, k8s)
 	}
 	return result
 }
 
 func (r *registry) GetInstaller(os, k8sVer string) osk8sInstaller {
-	return r.osk8sInstallerMap[os][k8sVer]
+	return r.resolveK8sInstallerMap(os)[k8sVer]
+}
+
+func (r* registry) resolveK8sInstallerMap(os string) k8sInstallerMap {
+	if res, ok := r.osk8sInstallerMap[os]; ok {
+		// There is direct match for the os
+		return res
+	}
+
+	// Try to find os using the alias map
+	for k,v := range r.aliasOSMap {
+		matched, _ := regexp.MatchString(k, os)
+		if matched {
+			return r.osk8sInstallerMap[v]
+		}
+	}
+
+	return nil
 }

--- a/agent/installer/registry_test.go
+++ b/agent/installer/registry_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 		})
 
                 It("Should be empty", func() {
-			Expect(r.ListOS()).To(HaveLen(0))
+			//Expect(r.ListOS()).To(HaveLen(0))
 			Expect(r.ListK8s("x")).To(HaveLen(0))
 			Expect(r.GetInstaller("a","b")).To(BeNil())
                 })
@@ -41,8 +41,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(r.GetInstaller("ubuntu","1.23")).To(Equal(dummy123))
 			Expect(r.GetInstaller("rhel","1.24")).To(Equal(dummy124))
 
-			Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
-			Expect(r.ListOS()).To(HaveLen(2))
+			//Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
+			//Expect(r.ListOS()).To(HaveLen(2))
 
 			Expect(r.ListK8s("ubuntu")).To(ContainElements("1.22", "1.23"))
 			Expect(r.ListK8s("ubuntu")).To(HaveLen(2))
@@ -51,8 +51,8 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(r.ListK8s("rhel")).To(HaveLen(1))
 
 			Expect(r.GetInstaller("photon","1.22")).To(BeNil())
-			Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
-			Expect(r.ListOS()).To(HaveLen(2))
+			//Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
+			//Expect(r.ListOS()).To(HaveLen(2))
 
 	        })
 		It("Should panic on duplicate installers", func() {

--- a/agent/installer/registry_test.go
+++ b/agent/installer/registry_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var _ = Describe("Byohost Installer Tests", func() {
-	 Context("When registry is created", func() {
+	Context("When registry is created", func() {
 		type dummyinstaller int
 
 		const (
@@ -24,25 +24,32 @@ var _ = Describe("Byohost Installer Tests", func() {
 		)
 
 		BeforeEach(func() {
-			r = NewRegistry()
+			r = newRegistry()
 		})
 
-                It("Should be empty", func() {
-			//Expect(r.ListOS()).To(HaveLen(0))
+		It("Should be empty", func() {
+			osFilters, osBundles := r.ListOS()
+			Expect(osFilters).To(HaveLen(0))
+			Expect(osBundles).To(HaveLen(0))
 			Expect(r.ListK8s("x")).To(HaveLen(0))
-			Expect(r.GetInstaller("a","b")).To(BeNil())
-                })
-	        It("Should allow working with installers", func() {
-			Expect(func() { r.Add("ubuntu", "1.22", dummy122) }).NotTo(Panic())
-			Expect(func() { r.Add("ubuntu", "1.23", dummy123) }).NotTo(Panic())
-			Expect(func() { r.Add("rhel", "1.24", dummy124) }).NotTo(Panic())
+			Expect(r.GetInstaller("a", "b")).To(BeNil())
+		})
+		It("Should allow working with installers", func() {
+			Expect(func() { r.AddBundleInstaller("ubuntu", "1.22", dummy122) }).NotTo(Panic())
+			Expect(func() { r.AddBundleInstaller("ubuntu", "1.23", dummy123) }).NotTo(Panic())
+			Expect(func() { r.AddBundleInstaller("rhel", "1.24", dummy124) }).NotTo(Panic())
+			r.AddOsFilter("ubuntu.*", "ubuntu")
+			r.AddOsFilter("rhel.*", "rhel")
 
-			Expect(r.GetInstaller("ubuntu","1.22")).To(Equal(dummy122))
-			Expect(r.GetInstaller("ubuntu","1.23")).To(Equal(dummy123))
-			Expect(r.GetInstaller("rhel","1.24")).To(Equal(dummy124))
+			Expect(r.GetInstaller("ubuntu-1", "1.22")).To(Equal(dummy122))
+			Expect(r.GetInstaller("ubuntu-2", "1.23")).To(Equal(dummy123))
+			Expect(r.GetInstaller("rhel-1", "1.24")).To(Equal(dummy124))
 
-			//Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
-			//Expect(r.ListOS()).To(HaveLen(2))
+			osFilters, osBundles := r.ListOS()
+			Expect(osFilters).To(ContainElements("rhel.*", "ubuntu.*"))
+			Expect(osFilters).To(HaveLen(2))
+			Expect(osBundles).To(ContainElements("rhel", "ubuntu"))
+			Expect(osBundles).To(HaveLen(2))
 
 			Expect(r.ListK8s("ubuntu")).To(ContainElements("1.22", "1.23"))
 			Expect(r.ListK8s("ubuntu")).To(HaveLen(2))
@@ -50,19 +57,22 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(r.ListK8s("rhel")).To(ContainElement("1.24"))
 			Expect(r.ListK8s("rhel")).To(HaveLen(1))
 
-			Expect(r.GetInstaller("photon","1.22")).To(BeNil())
-			//Expect(r.ListOS()).To(ContainElements("rhel", "ubuntu"))
-			//Expect(r.ListOS()).To(HaveLen(2))
+			Expect(r.GetInstaller("photon", "1.22")).To(BeNil())
+			osFilters, osBundles = r.ListOS()
+			Expect(osFilters).To(ContainElements("rhel.*", "ubuntu.*"))
+			Expect(osFilters).To(HaveLen(2))
+			Expect(osBundles).To(ContainElements("rhel", "ubuntu"))
+			Expect(osBundles).To(HaveLen(2))
 
-	        })
+		})
 		It("Should panic on duplicate installers", func() {
 			/*
 			 * Add is expected to be called with literals only.
 			 * Adding a mapping to already existing os and k8s is clearly a typo and bug.
 			 * Make it obvious
 			 */
-			Expect(func() { r.Add("ubuntu", "1.22", dummy122) }).NotTo(Panic())
-			Expect(func() { r.Add("ubuntu", "1.22", dummy1122) }).To(Panic())
+			Expect(func() { r.AddBundleInstaller("ubuntu", "1.22", dummy122) }).NotTo(Panic())
+			Expect(func() { r.AddBundleInstaller("ubuntu", "1.22", dummy1122) }).To(Panic())
 		})
 	})
 })


### PR DESCRIPTION
A BYOH bundle and installer Algo are developed and tested using a specific OS version (including patch version).
This is why the patch version is included in the BYOH bundle name. An old BYOH Bundle may work with newer OS patches and versions.

This PR make the installer smart. It can map any OS version to any BYOH Bundle and installer Algo.

Registry contains
1. Entries associating BYOH Bundle in the Repository with Installer in Host Agent
2. Entries that match an OS to a BYOH Bundle OS in the Repository

cli --list-supported
```
OS                      K8S Version     BYOH Bundle Name
---                     -----------     ----------------
Ubuntu_20.04.*_x86-64    v1.22.1        byoh-bundle-ubuntu_20.04.1_x86-64_k8s_v1.22.1
```

Testing done
On a Ubuntu 18.04
./cli --list-supported
./cli --preview-os-changes --os Ubuntu_20.04.*_x86-64 --k8s v1.22.1
./cli --install --os Ubuntu_20.04.1_x86-64 --k8s v1.22.1 --bundle-repo <REPO>
./cli --uninstall --os Ubuntu_20.04.1_x86-64 --k8s v1.22.1 --bundle-repo <REPO>