### PR TITLE
Add more ldflags for host agent binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,8 @@ GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 
 BYOH_TEMPLATES := $(REPO_ROOT)/test/e2e/data/infrastructure-provider-byoh
 
+LDFLAGS=-w -s
+STATIC=-extldflags '-static'
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -151,7 +153,7 @@ kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.9.1)
 
 host-agent-binaries: ## Builds the binaries for the host-agent
-	RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 HOST_AGENT_DIR=./$(HOST_AGENT_DIR) $(MAKE) host-agent-binary
+	RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 GOLDFLAGS="$(LDFLAGS) $(STATIC)" HOST_AGENT_DIR=./$(HOST_AGENT_DIR) $(MAKE) host-agent-binary
 
 host-agent-binary: $(RELEASE_DIR)
 	docker run \
@@ -162,7 +164,7 @@ host-agent-binary: $(RELEASE_DIR)
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
 		golang:1.16.6 \
-		go build -a -ldflags "$(LDFLAGS) -extldflags '-static'" \
+		go build -a -ldflags "$(GOLDFLAGS)" \
 		-o ./bin/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(HOST_AGENT_DIR)
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:
We can add ldflags=`-w -s` to strip down debugging info from the binary.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/issues/210

**Additional information**

Before:
```
$ make host-agent-binaries
RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 HOST_AGENT_DIR=./agent /Library/Developer/CommandLineTools/usr/bin/make host-agent-binary
docker run \
                --rm \
                -e CGO_ENABLED=0 \
                -e GOOS=linux \
                -e GOARCH=amd64 \
                -v "$(pwd):/workspace" \
                -w /workspace \
                golang:1.16.6 \
                go build -a -ldflags " -extldflags '-static'" \
                -o ./bin/byoh-hostagent-linux-amd64 ./agent
```

After:
```
$ make host-agent-binaries
RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 GOLDFLAGS="-w -s -extldflags '-static'" HOST_AGENT_DIR=./agent /Library/Developer/CommandLineTools/usr/bin/make host-agent-binary
docker run \
                --rm \
                -e CGO_ENABLED=0 \
                -e GOOS=linux \
                -e GOARCH=amd64 \
                -v "$(pwd):/workspace" \
                -w /workspace \
                golang:1.16.6 \
                go build -a -ldflags "-w -s -extldflags '-static'" \
                -o ./bin/byoh-hostagent-linux-amd64 ./agent
```

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->