### PR TITLE
Use --short to report kubectl version

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -18,5 +18,5 @@ about: Tell us about a problem you are experiencing
 **Environment:**
 
 - Cluster-api-provider-bringyourownhost version: 
-- Kubernetes version: (use `kubectl version`): 
-- OS (e.g. from `/etc/os-release`): 
+- Kubernetes version: (use `kubectl version --short`):
+- OS (e.g. from `/etc/os-release`):

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,11 +9,11 @@ about: Suggest an idea for this project
 
 
 **Anything else you would like to add:**
-[Miscellaneous information that will assist in solving the issue.]
+[Miscellaneous information that will assist in implementing the feature.]
 
 
 **Environment:**
 
 - Cluster-api-provider-bringyourownhost version: 
-- Kubernetes version: (use `kubectl version`): 
-- OS (e.g. from `/etc/os-release`): 
+- Kubernetes version: (use `kubectl version --short`):
+- OS (e.g. from `/etc/os-release`):


### PR DESCRIPTION
**What this PR does / why we need it**:
Before:
```
$ kubectl version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.2", GitCommit:"8b5a19147530eaac9476b0ab82980b4088bbc1b2",
GitTreeState:"clean", BuildDate:"2021-09-15T21:31:32Z", GoVersion:"go1.16.8", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.1", GitCommit:"5e58841cce77d4bc13713ad2b91fa0d961e69192",
GitTreeState:"clean", BuildDate:"2021-05-21T23:01:33Z", GoVersion:"go1.16.4", Compiler:"gc", Platform:"linux/amd64"}
```

After:
```
$ kubectl version --short
Client Version: v1.22.2
Server Version: v1.21.1
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->