### PR TITLE
Strip version tag from k8s version

### DIFF
--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"time"
 
 	"k8s.io/apimachinery/pkg/labels"
@@ -464,7 +465,7 @@ func (r *ByoMachineReconciler) attachByoHost(ctx context.Context, machineScope *
 		host.Annotations = make(map[string]string)
 	}
 	host.Annotations[infrav1.EndPointIPAnnotation] = machineScope.Cluster.Spec.ControlPlaneEndpoint.Host
-	host.Annotations[infrav1.K8sVersionAnnotation] = *machineScope.Machine.Spec.Version
+	host.Annotations[infrav1.K8sVersionAnnotation] = strings.Split(*machineScope.Machine.Spec.Version, "_")[0]
 	host.Annotations[infrav1.BundleLookupBaseRegistryAnnotation] = machineScope.ByoCluster.Spec.BundleLookupBaseRegistry
 	host.Annotations[infrav1.BundleLookupTagAnnotation] = machineScope.ByoCluster.Spec.BundleLookupTag
 

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 		machine             *clusterv1.Machine
 		k8sClientUncached   client.Client
 		byoHost             *infrastructurev1beta1.ByoHost
+		testClusterVersion  = "v1.22.1_xyz"
 	)
 
 	BeforeEach(func() {
@@ -45,7 +46,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 
 		machine = builder.Machine(defaultNamespace, defaultMachineName).
 			WithClusterName(defaultClusterName).
-			WithClusterVersion("1.22").
+			WithClusterVersion(testClusterVersion).
 			WithBootstrapDataSecret(fakeBootstrapSecret).
 			Build()
 		Expect(k8sClientUncached.Create(ctx, machine)).Should(Succeed())
@@ -204,11 +205,8 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				createdByoHostLabels := createdByoHost.GetLabels()
 				Expect(createdByoHostLabels[clusterv1.ClusterLabelName]).To(Equal(capiCluster.Name))
 
-				// Assert annotations on byohost
-				testClusterVersion := "1.22"
 				createdByoHostAnnotations := createdByoHost.GetAnnotations()
-
-				Expect(createdByoHostAnnotations[infrastructurev1beta1.K8sVersionAnnotation]).To(Equal(testClusterVersion))
+				Expect(createdByoHostAnnotations[infrastructurev1beta1.K8sVersionAnnotation]).To(Equal(strings.Split(testClusterVersion, "_")[0]))
 				Expect(createdByoHostAnnotations[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation]).To(Equal(byoCluster.Spec.BundleLookupBaseRegistry))
 				Expect(createdByoHostAnnotations[infrastructurev1beta1.BundleLookupTagAnnotation]).To(Equal(byoCluster.Spec.BundleLookupTag))
 

--- a/test/builder/builders.go
+++ b/test/builder/builders.go
@@ -130,7 +130,7 @@ type MachineBuilder struct {
 	bootstrapDataSecret string
 }
 
-// ClusterBuilder holds the variables and objects required to build a clusterv1.Cluster
+// ByoClusterBuilder holds the variables and objects required to build a infrastructurev1beta1.ByoCluster
 type ByoClusterBuilder struct {
 	namespace      string
 	name           string
@@ -138,7 +138,7 @@ type ByoClusterBuilder struct {
 	bundleTag      string
 }
 
-// Cluster returns a ByoClusterBuilder with the given name and namespace
+// ByoCluster returns a ByoClusterBuilder with the given name and namespace
 func ByoCluster(namespace, name string) *ByoClusterBuilder {
 	return &ByoClusterBuilder{
 		namespace: namespace,


### PR DESCRIPTION


Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
The byomachine controller will strip any version tag from k8sversion
before setting the annotation on byohost
