### PR TITLE
Update default value for downloadpath

### DIFF
--- a/agent/main.go
+++ b/agent/main.go
@@ -86,7 +86,7 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "default", "Namespace in the management cluster where you would like to register this host")
 	flag.Var(&labels, "label", "labels to attach to the ByoHost CR in the form labelname=labelVal for e.g. '--label site=apac --label cores=2'")
 	flag.StringVar(&metricsbindaddress, "metricsbindaddress", ":8080", "metricsbindaddress is the TCP address that the controller should bind to for serving prometheus metrics.It can be set to \"0\" to disable the metrics serving")
-	flag.StringVar(&downloadpath, "downloadpath", "/var/lib", "File System path to keep the downloads")
+	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/kubernetes-artifacts", "File System path to keep the downloads")
 	flag.BoolVar(&skipInstallation, "skip-installation", false, "If you want to skip installation of the kubernetes component binaries")
 	klog.InitFlags(nil)
 	flag.Parse()

--- a/agent/main.go
+++ b/agent/main.go
@@ -86,7 +86,7 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "default", "Namespace in the management cluster where you would like to register this host")
 	flag.Var(&labels, "label", "labels to attach to the ByoHost CR in the form labelname=labelVal for e.g. '--label site=apac --label cores=2'")
 	flag.StringVar(&metricsbindaddress, "metricsbindaddress", ":8080", "metricsbindaddress is the TCP address that the controller should bind to for serving prometheus metrics.It can be set to \"0\" to disable the metrics serving")
-	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/kubernetes-artifacts", "File System path to keep the downloads")
+	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/byoh/kubernetes-artifacts", "File System path to keep the downloads")
 	flag.BoolVar(&skipInstallation, "skip-installation", false, "If you want to skip installation of the kubernetes component binaries")
 	klog.InitFlags(nil)
 	flag.Parse()

--- a/agent/main.go
+++ b/agent/main.go
@@ -86,7 +86,7 @@ func main() {
 	flag.StringVar(&namespace, "namespace", "default", "Namespace in the management cluster where you would like to register this host")
 	flag.Var(&labels, "label", "labels to attach to the ByoHost CR in the form labelname=labelVal for e.g. '--label site=apac --label cores=2'")
 	flag.StringVar(&metricsbindaddress, "metricsbindaddress", ":8080", "metricsbindaddress is the TCP address that the controller should bind to for serving prometheus metrics.It can be set to \"0\" to disable the metrics serving")
-	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/byoh/kubernetes-artifacts", "File System path to keep the downloads")
+	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/byoh/bundles", "File System path to keep the downloads")
 	flag.BoolVar(&skipInstallation, "skip-installation", false, "If you want to skip installation of the kubernetes component binaries")
 	klog.InitFlags(nil)
 	flag.Parse()


### PR DESCRIPTION


**What this PR does / why we need it**:
Updating the default to `/var/lib/kubernetes-artifacts` to be more clear
on the intent of the downloaded components

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #218 
