### PR TITLE
Fix installer Ubuntu_20.04.3_x86-64 bug

### DIFF
--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -15,7 +15,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 
 	Context("When installer is created for unsupported OS", func() {
 		It("Should return error", func() {
-			_, err := New("repo", "downloadPath", logr.Discard())
+			_, err := newUnchecked("Ubuntu_99.04.3_x86-64", "", "", logr.Discard(), nil)
 			Expect(err).Should((HaveOccurred()))
 		})
 	})

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -75,12 +75,17 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(osList).ShouldNot(BeEmpty())
 		})
 	})
-	Context("When ListSupportedK8s is called for all supported OSes", func() {
+	Context("When ListSupportedK8s is called for all supported bundle OSes", func() {
 		It("Should return non-empty result", func() {
 			_, osList := ListSupportedOS()
-			for _, os := range osList {
-				Expect(ListSupportedK8s(os)).ShouldNot(BeEmpty())
+			for _, osBundle := range osList {
+				Expect(ListSupportedK8s(osBundle)).ShouldNot(BeEmpty())
 			}
+		})
+	})
+	Context("When ListSupportedK8s is called for supported host OS", func() {
+		It("Should return non-empty result", func() {
+			Expect(ListSupportedK8s("Ubuntu_20.04.3_x86-64")).ShouldNot(BeEmpty())
 		})
 	})
 	Context("When PreviewChanges is called for all supported os and k8s", func() {
@@ -114,6 +119,12 @@ var _ = Describe("Byohost Installer Tests", func() {
 			_, _, err := PreviewChanges(os, k8s)
 			Expect(err).Should((HaveOccurred()))
 			Expect(err).Should(Equal(ErrOsK8sNotSupported))
+		})
+	})
+	Context("When installer is created", func() {
+		It("Should be possible to do so using host os or bundle os ", func() {
+			Expect(func() { NewPreviewInstaller("Ubuntu_20.04.1_x86-64", nil) }).NotTo(Panic())
+			Expect(func() { NewPreviewInstaller("Ubuntu_20.04.3_x86-64", nil) }).NotTo(Panic())
 		})
 	})
 })

--- a/agent/installer/registry.go
+++ b/agent/installer/registry.go
@@ -57,16 +57,30 @@ func (r *registry) ListOS() (osFilter, osBundle []string) {
 	return
 }
 
-func (r *registry) ListK8s(osBundle string) []string {
-	result := make([]string, 0, len(r.osk8sInstallerMap[osBundle]))
-	for k8s := range r.osk8sInstallerMap[osBundle] {
+func (r *registry) ListK8s(osBundleHost string) []string {
+	var result []string
+
+	// os bundle
+	if k8sMap, ok := r.osk8sInstallerMap[osBundleHost]; ok {
+		for k8s := range k8sMap {
+			result = append(result, k8s)
+		}
+
+		return result
+	}
+
+	// os host
+	for k8s := range r.osk8sInstallerMap[r.resolveOsToOsBundle(osBundleHost)] {
 		result = append(result, k8s)
 	}
+
 	return result
 }
 
-func (r *registry) GetInstaller(osHost, k8sVer string) osk8sInstaller {
-	return r.osk8sInstallerMap[r.resolveOsToOsBundle(osHost)][k8sVer]
+func (r *registry) GetInstaller(osHost, k8sVer string) (osk8si osk8sInstaller, osBundle string) {
+	osBundle = r.resolveOsToOsBundle(osHost)
+	osk8si = r.osk8sInstallerMap[osBundle][k8sVer]
+	return
 }
 
 func (r *registry) resolveOsToOsBundle(os string) string {


### PR DESCRIPTION
Problem
When running cli with os flag set to "Ubuntu_20.04.3_x86-64", installer returns
"os k8s not supported". Installer is expected to support Ubuntu_20.04.*_x86-64
and treat them as Ubuntu_20.04.1_x86-64.

Rootcause
Installer runs a check whether there is at least one k8s for the os.
It does so by using registry ListK8s. However the latter expects that
its argument is an osBundle (Ubuntu_20.04.1_x86-64) as returned by
registry ListOS. There is no os bundle for "Ubuntu_20.04.3_x86-64".

Fix
registry ListK8s needs to support 2 use-cases. First, when called
with an actual OS to be mutated. Second, when called with list-supported
which may be on a non supported OS. Extend registry ListK8s to use the os
regex in addition to the os bundle. Extend registry to return the os bundle
in addition to installer.