### PR TITLE
Implemented fix to avoid the errors occuring during normal uninstallation.

### DIFF
--- a/agent/installer/internal/algo/ubuntu20_4K8s1_22.go
+++ b/agent/installer/internal/algo/ubuntu20_4K8s1_22.go
@@ -44,7 +44,7 @@ func (u *Ubuntu20_4K8s1_22) osWideCfgUpdateStep(bki *BaseK8sInstaller) Step {
 		confAbsolutePath)
 
 	undoCmd := fmt.Sprintf(
-		"tar tf '%s' | xargs -n 1 echo '/' | sed 's/ //g' | xargs rm -f",
+		"tar tf %s | xargs -n 1 echo '/' | sed 's/ //g' | while IFS= read -r file; do   [ -d \"$file\" ] || printf '%%s\n' \"$file\"; done | xargs rm",
 		confAbsolutePath)
 
 	return &ShellStep{


### PR DESCRIPTION
Errors were occurring on step OS CONFRIGURATION because it was checking both files and directories.
Now during the uninstallation first the list is filtered to include only files and then it tries to delete them.