### PR TITLE
Documented cgroupfs driver use in the getting started guide

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -154,6 +154,10 @@ $ CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster
     --control-plane-machine-count 1 \
     --worker-machine-count 1 > cluster.yaml
 
+# For docker hosts, update cgroup driver to cgroupfs
+$ sed -i '/^          kubeletExtraArgs:/a\            cgroup-driver: cgroupfs' cluster.yaml
+$ sed -i '/^        kubeletExtraArgs:/a\          cgroup-driver: cgroupfs' cluster.yaml
+
 # Inspect and make any changes
 $ vi cluster.yaml
 


### PR DESCRIPTION
Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:
BYOH will use `systemd` as default group driver and same will be used in release artifacts(`infrastructure-components.yaml`, `cluster-template.yaml`).
This PR will update getting started guide to use `cgroupfs` cgroup driver for docker hosts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->