### PR TITLE
Create draft release automation

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Release Artifacts
-        run: make build-release-artifacts
+        run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ env.GITHUB_REF }}" make build-release-artifacts
 
       - name: Publish Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -1,0 +1,32 @@
+name: Draft Release
+
+on:
+  push:
+    # Build and publish artifacts when new tag is created for release
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Build Release Artifacts
+        run: make build-release-artifacts
+
+      - name: Publish Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          draft: true
+          generate_release_notes: true
+          files: |
+            _dist/byoh-hostagent-linux-amd64
+            _dist/cluster-template.yaml
+            _dist/infrastructure-components.yaml
+            _dist/metadata.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
       - name: Build Release Artifacts
         run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ env.GITHUB_REF }}" make build-release-artifacts
 

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ bin
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Distribution related files
+_dist
+
 # Kubernetes Generated files - skip generated files, except for vendored files
 
 !vendor/**/zz_generated.*

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,7 @@ build-release-artifacts: build-cluster-templates build-infra-yaml build-metadata
 
 build-cluster-templates: $(RELEASE_DIR) cluster-templates
 	cp $(BYOH_TEMPLATES)/v1beta1/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
-	sed -i -e 1,7d $(RELEASE_DIR)/cluster-template.yaml
+	sed -i -e 1,20d $(RELEASE_DIR)/cluster-template.yaml
 
 build-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider
 	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller=${IMG}

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ STAGING_REGISTRY ?= gcr.io/k8s-staging-cluster-api
 
 IMAGE_NAME ?= cluster-api-byoh-controller
 TAG ?= dev
+RELEASE_DIR := _dist
 
 # Image URL to use all building/pushing image targets
 IMG ?= ${STAGING_REGISTRY}/${IMAGE_NAME}:${TAG}
@@ -166,6 +167,29 @@ host-agent-binary: $(RELEASE_DIR)
 		golang:1.16.6 \
 		go build -a -ldflags "$(GOLDFLAGS)" \
 		-o ./bin/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(HOST_AGENT_DIR)
+
+
+##@Release
+
+$(RELEASE_DIR):
+	rm -rf $(RELEASE_DIR)
+	mkdir -p $(RELEASE_DIR)
+
+build-release-artifacts: build-cluster-templates build-infra-yaml build-metadata-yaml build-host-agent-binary
+
+build-cluster-templates: $(RELEASE_DIR) cluster-templates
+	cp $(BYOH_TEMPLATES)/v1beta1/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
+	sed -i -e 1,7d $(RELEASE_DIR)/cluster-template.yaml
+
+build-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider
+	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller=${IMG}
+	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/infrastructure-components.yaml
+
+build-metadata-yaml:
+	cp metadata.yaml $(RELEASE_DIR)/metadata.yaml
+
+build-host-agent-binary: host-agent-binaries
+	cp bin/byoh-hostagent-linux-amd64 $(RELEASE_DIR)/byoh-hostagent-linux-amd64
 
 
 # go-get-tool will 'go get' any package $2 and install it to $1.

--- a/Makefile
+++ b/Makefile
@@ -181,7 +181,6 @@ build-cluster-templates: $(RELEASE_DIR) cluster-templates
 	cp $(BYOH_TEMPLATES)/v1beta1/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
 	sed -i -e 1,20d $(RELEASE_DIR)/cluster-template.yaml
 
-IMG=projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:rel-tag
 build-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider
 	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller=${IMG}
 	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/infrastructure-components.yaml

--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,7 @@ build-cluster-templates: $(RELEASE_DIR) cluster-templates
 	cp $(BYOH_TEMPLATES)/v1beta1/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
 	sed -i -e 1,20d $(RELEASE_DIR)/cluster-template.yaml
 
+IMG=projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:rel-tag
 build-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider
 	cd config/manager && $(KUSTOMIZE) edit set image gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller=${IMG}
 	$(KUSTOMIZE) build config/default > $(RELEASE_DIR)/infrastructure-components.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:
Resumption of https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/pull/183

**Which issue(s) this PR fixes**:
Fixes https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/issues/181

**Additional information**
Uses https://github.com/softprops/action-gh-release
_Note_: This needs to be tested carefully as it affects release artifacts and release notes.

**Special notes for your reviewer**
Tested with act https://github.com/nektos/act

```
$ act -j build
[Draft Release/build] 🚀  Start image=catthehacker/ubuntu:act-latest
[Draft Release/build]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["/usr/bin/tail" "-f" "/dev/null"] cmd=[]
[Draft Release/build]   🐳  docker exec cmd=[mkdir -m 0777 -p /var/run/act] user=root
[Draft Release/build]   🐳  docker cp src=/Users/shamshera/Projects/cluster-api-provider-bringyourownhost/. dst=/Users/shamshera/Projects/cluster-api-provider-bringyourownhost
[Draft Release/build]   🐳  docker exec cmd=[mkdir -p /Users/shamshera/Projects/cluster-api-provider-bringyourownhost] user=
[Draft Release/build] ⭐  Run Checkout
[Draft Release/build]   ✅  Success - Checkout
[Draft Release/build] ⭐  Run Set up Go
INFO[0001]   ☁  git clone 'https://github.com/actions/setup-go' # ref=v2 
[Draft Release/build]   🐳  docker cp src=/Users/shamshera/.cache/act/actions-setup-go@v2/ dst=/var/run/act/actions/actions-setup-go@v2/
[Draft Release/build]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/actions-setup-go@v2/] user=
[Draft Release/build]   🐳  docker exec cmd=[node /var/run/act/actions/actions-setup-go@v2/dist/index.js] user=
| Setup go stable version spec 1.16
| Successfully setup go version 1.16
[Draft Release/build]   ❓  ##[add-matcher]/run/act/actions/actions-setup-go@v2/matchers.json
| go version go1.16.10 linux/amd64

| GOGCCFLAGS="-fPIC -m64 -pthread -fmessage-length=0 -fdebug-prefix-map=/tmp/go-build3249229116=/tmp/go-build -gno-record-gcc-switches"
| 
[Draft Release/build]   ❓  ::endgroup::
[Draft Release/build]   ✅  Success - Set up Go
[Draft Release/build] ⭐  Run Build Release Artifacts
[Draft Release/build]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/workflow/2] user=
| rm -rf _dist
| mkdir -p _dist
| go: creating new go.mod: module tmp

/Users/shamshera/Projects/cluster-api-provider-bringyourownhost/bin/kustomize build /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/test/e2e/data/infrastructure-provider-byoh/v1beta1 --load_restrictor none > /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml
| cp /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml _dist/cluster-template.yaml
| sed -i -e 1,20d _dist/cluster-template.yaml
| cd config/manager && /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/bin/kustomize edit set image gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller=projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:refs/heads/draft-release
| /Users/shamshera/Projects/cluster-api-provider-bringyourownhost/bin/kustomize build config/default > _dist/infrastructure-components.yaml
| cp metadata.yaml _dist/metadata.yaml
```

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->