### PR TITLE
🐛 Fix Draft Release Github action to fetch the tag name

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.16
 
       - name: Build Release Artifacts
-        run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ env.GITHUB_REF }}" make build-release-artifacts
+        run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ github.ref_name }}" make build-release-artifacts
 
       - name: Publish Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
`env.GITHUB_REF` is replaced with `github.ref_name` as this variable contains the branch or tag name that triggered the workflow run. Refer this - https://docs.github.com/en/actions/learn-github-actions/contexts#github-context

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #281 

**Additional information**


**Special notes for your reviewer**

Performed validation in this repo https://github.com/dharmjit/cluster-api-provider-bringyourownhost. Refer - `Job Test Output` for https://github.com/dharmjit/cluster-api-provider-bringyourownhost/runs/4505890775?check_suite_focus=true or the draft release assets.
