### PR TITLE
Update k8s version to v1.22.3 in all docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ RELEASE_DIR := _dist
 
 # Image URL to use all building/pushing image targets
 IMG ?= ${STAGING_REGISTRY}/${IMAGE_NAME}:${TAG}
-BYOH_BASE_IMG = byoh/node:v1.22.0
+BYOH_BASE_IMG = byoh/node:v1.22.3
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -90,7 +90,7 @@ Once the image is ready, lets start 2 docker containers for our deployment. One 
 for i in {1..2}
 do
   echo "Creating docker container named host$i"
-  docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh/node:v1.22.0
+  docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh/node:v1.22.3
 done
 ```
 
@@ -121,7 +121,7 @@ $ cat /etc/hosts
 ```
 
 If you are trying this on your own hosts, then for each host
-1. Download the [byoh-hostagent-linux-amd64](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.1.0-alpha.2/byoh-hostagent-linux-amd64)
+1. Download the [byoh-hostagent-linux-amd64](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.1.0/byoh-hostagent-linux-amd64)
 2. Copy the management cluster `kubeconfig` file as `management.conf`
 3. Start the agent 
 ```shell
@@ -147,15 +147,15 @@ echo "Copy kubeconfig to host $i"
 docker cp ~/.kube/management-cluster.conf host$i:/management-cluster.conf
 done
 ```
-Start the host agent on each of the hosts and keep it running
+Start the host agent on each of the hosts and keep it running. Use the `--skip-installation` flag as we already have k8s components included in the docker image. This flag will skip k8s installation attempt on the host
 
 ```shell
 export HOST_NAME=host1
-docker exec -it $HOST_NAME sh -c "chmod +x byoh-hostagent && ./byoh-hostagent --kubeconfig management-cluster.conf"
+docker exec -it $HOST_NAME sh -c "chmod +x byoh-hostagent && ./byoh-hostagent --kubeconfig management-cluster.conf --skip-installation"
 
 # do the same for host2 in a separate tab
 export HOST_NAME=host2
-docker exec -it $HOST_NAME sh -c "chmod +x byoh-hostagent && ./byoh-hostagent --kubeconfig management-cluster.conf"
+docker exec -it $HOST_NAME sh -c "chmod +x byoh-hostagent && ./byoh-hostagent --kubeconfig management-cluster.conf --skip-installation"
 ```
 ---
 
@@ -171,15 +171,20 @@ Running the following command(on the host where you execute `clusterctl` in prev
 **NOTE:** The `CONTROL_PLANE_ENDPOINT_IP` is an IP that must be an IP on the same subnet as the control plane machines, it should be also an IP that is not part of your DHCP range
 
 ```shell
+# for vms as byohosts
 $ CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
     --infrastructure byoh \
     --kubernetes-version v1.22.3 \
     --control-plane-machine-count 1 \
     --worker-machine-count 1 > cluster.yaml
 
-# For docker hosts, update cgroup driver to cgroupfs
-$ sed -i '/^          kubeletExtraArgs:/a\            cgroup-driver: cgroupfs' cluster.yaml
-$ sed -i '/^        kubeletExtraArgs:/a\          cgroup-driver: cgroupfs' cluster.yaml
+# for docker hosts use the --flavor argument
+$ CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
+    --infrastructure byoh \
+    --kubernetes-version v1.22.3 \
+    --control-plane-machine-count 1 \
+    --worker-machine-count 1 \
+    --flavor docker > cluster.yaml
 
 # Inspect and make any changes
 $ vi cluster.yaml

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -101,7 +101,7 @@ Run the following to create n hosts, where ```n>1```
 for i in {1..n}
 do
 echo "Creating docker container host $i"
-docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh/node:v1.22.0
+docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh/node:v1.22.3
 echo "Copy agent binary to host $i"
 docker cp bin/byoh-hostagent-linux-amd64 host$i:/byoh-hostagent
 echo "Copy kubeconfig to host $i"
@@ -131,7 +131,7 @@ Open a new shell and change directory to `cluster-api-provider-bringyourownhost`
 ```shell
 export CLUSTER_NAME="test1"
 export NAMESPACE="default"
-export KUBERNETES_VERSION="v1.22.0"
+export KUBERNETES_VERSION="v1.22.3"
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export CONTROL_PLANE_ENDPOINT_IP=<static IP from the subnet where the containers are running>

--- a/test/e2e/BYOHDockerFile
+++ b/test/e2e/BYOHDockerFile
@@ -16,7 +16,7 @@ RUN echo "Installing kubectl kubeadm kubelet" \
     && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && apt-get update \
     && apt-get install -y linux-image-$(uname -r) \
-    && apt-get install -y kubelet=1.22.0-00 kubeadm=1.22.0-00 kubectl=1.22.0-00 \
+    && apt-get install -y kubelet=1.22.3-00 kubeadm=1.22.3-00 kubectl=1.22.3-00 \
     && apt-mark hold containerd kubelet kubeadm kubectl \
     && apt-get clean \
     && systemctl enable kubelet.service \

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -79,7 +79,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.22.0"
+  KUBERNETES_VERSION: "v1.22.3"
   ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
   COREDNS_VERSION_UPGRADE_TO: "1.7.0"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	KindImage          = "byoh/node:v1.22.0"
+	KindImage          = "byoh/node:v1.22.3"
 	TempKubeconfigPath = "/tmp/mgmt.conf"
 )
 


### PR DESCRIPTION


**What this PR does / why we need it**:
- update byoh docker host image to v1.22.3
- update getting started guide and local-dev guide
- update default k8s version to v1.22.3 in e2e tests

Fixes #268 
