### PR TITLE
Handle bundleLookupTag in e2e tests

### DIFF
--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -135,6 +135,7 @@ export KUBERNETES_VERSION="v1.22.3"
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 export CONTROL_PLANE_ENDPOINT_IP=<static IP from the subnet where the containers are running>
+export BUNDLE_LOOKUP_TAG=<bundle tag>
 ```
 
 From ```cluster-api-provider-bringyourownhost``` folder

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -95,6 +95,7 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.0/clusterctl-{OS}-{ARCH}"
+  BUNDLE_LOOKUP_TAG: "v0.1.0_alpha.2"
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-template.yaml
@@ -184,7 +184,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
-  bundleLookupTag: v0.1.0_alpha.2
+  bundleLookupTag: ${BUNDLE_LOOKUP_TAG}
   controlPlaneEndpoint:
     host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/cluster-with-kcp.yaml
@@ -28,7 +28,7 @@ metadata:
   name: ${CLUSTER_NAME}
 spec:
   bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
-  bundleLookupTag: v0.1.0_alpha.2
+  bundleLookupTag: ${BUNDLE_LOOKUP_TAG}
   controlPlaneEndpoint:
     host: ${CONTROL_PLANE_ENDPOINT_IP}
     port: 6443


### PR DESCRIPTION
This issue is the second half of the problem mentioned in #259.  The bundleLookupTag is currently hardcoded in the e2e test. While this works for now, this value should be configurable. 

Signed-off-by: Hui Chen <huchen@huchen-a01.vmware.com>

Fixes #303 