### PR TITLE
We should refactor the agent cli output

### DIFF
--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -1,0 +1,47 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"os/exec"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("Help flag for host agent", func() {
+	Context("When the help flag is provided", func() {
+		var (
+			expectedOptions = []string{
+				"-downloadpath string",
+				"-kubeconfig string",
+				"-label value",
+				"-metricsbindaddress string",
+				"-namespace string",
+				"-skip-installation",
+			}
+		)
+
+		It("should output the expected option", func() {
+			command := exec.Command(pathToHostAgentBinary, "--help")
+			session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(session, "5s").Should(gexec.Exit(0))
+
+			output := string(session.Err.Contents())
+			for _, line := range strings.Split(strings.TrimRight(output, "\n"), "\n") {
+				line = strings.TrimSpace(line)
+				if !strings.HasPrefix(line, "-") {
+					continue
+				}
+				// Any option not belongs to expectedOptions is not allowed.
+				Expect(line).To(BeElementOf(expectedOptions))
+			}
+
+		})
+
+	})
+})

--- a/agent/installer/cli.go
+++ b/agent/installer/cli.go
@@ -14,16 +14,16 @@ import (
 )
 
 var (
-	listSupportedFlag    = flag.Bool("list-supported", false, "List all supported OS, Kubernetes versions and BYOH Bundle names")
-	detectOSFlag         = flag.Bool("detect", false, "Detects the current operating system")
-	installFlag          = flag.Bool("install", false, "Install a BYOH Bundle")
-	uninstallFlag        = flag.Bool("uninstall", false, "Unnstall a BYOH Bundle")
-	bundleRepoFlag       = flag.String("bundle-repo", "projects.registry.vmware.com", "BYOH Bundle Repository")
-	cachePathFlag        = flag.String("cache-path", ".", "Path to the local bundle cache")
-	k8sFlag              = flag.String("k8s", "1.22.1", "Kubernetes version")
-	osFlag               = flag.String("os", "", "OS. If used with install/uninstall, override os detection")
-	tagFlag              = flag.String("tag", "", "BYOH Bundle tag")
-	previewOSChangesFlag = flag.Bool("preview-os-changes", false, "Preview the install and uninstall changes for the specified OS")
+	listSupportedFlag    *bool
+	detectOSFlag         *bool
+	installFlag          *bool
+	uninstallFlag        *bool
+	bundleRepoFlag       *string
+	cachePathFlag        *string
+	k8sFlag              *string
+	osFlag               *string
+	tagFlag              *string
+	previewOSChangesFlag *bool
 )
 
 const (
@@ -37,6 +37,17 @@ var (
 
 func Main() {
 	klogger = klogr.New()
+
+	listSupportedFlag = flag.Bool("list-supported", false, "List all supported OS, Kubernetes versions and BYOH Bundle names")
+	detectOSFlag = flag.Bool("detect", false, "Detects the current operating system")
+	installFlag = flag.Bool("install", false, "Install a BYOH Bundle")
+	uninstallFlag = flag.Bool("uninstall", false, "Unnstall a BYOH Bundle")
+	bundleRepoFlag = flag.String("bundle-repo", "projects.registry.vmware.com", "BYOH Bundle Repository")
+	cachePathFlag = flag.String("cache-path", ".", "Path to the local bundle cache")
+	k8sFlag = flag.String("k8s", "1.22.1", "Kubernetes version")
+	osFlag = flag.String("os", "", "OS. If used with install/uninstall, override os detection")
+	tagFlag = flag.String("tag", "", "BYOH Bundle tag")
+	previewOSChangesFlag = flag.Bool("preview-os-changes", false, "Preview the install and uninstall changes for the specified OS")
 
 	flag.Parse()
 

--- a/agent/main.go
+++ b/agent/main.go
@@ -17,7 +17,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 	"k8s.io/klog/klogr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -88,7 +87,6 @@ func main() {
 	flag.StringVar(&metricsbindaddress, "metricsbindaddress", ":8080", "metricsbindaddress is the TCP address that the controller should bind to for serving prometheus metrics.It can be set to \"0\" to disable the metrics serving")
 	flag.StringVar(&downloadpath, "downloadpath", "/var/lib/byoh/bundles", "File System path to keep the downloads")
 	flag.BoolVar(&skipInstallation, "skip-installation", false, "If you want to skip installation of the kubernetes component binaries")
-	klog.InitFlags(nil)
 	flag.Parse()
 	scheme = runtime.NewScheme()
 	_ = infrastructurev1beta1.AddToScheme(scheme)


### PR DESCRIPTION
Fixes #253

There are a lot of wrong flag for byoh-hostagent

1) The following flags belong to "cli", not " byoh-hostagent". It should put all flag function in main function of "cli", not as global variable.

- -bundle-repo string
- -cache-path string
- -detect
- -install
- -k8s string
- -list-supported
- -os string
- -preview-os-changes
- -tag string
- -uninstall

2) The following flags belong to klog which we don't need it anymore

- -add_dir_header
- -alsologtostderr
- -log_backtrace_at value
- -log_dir string
- -log_file string
- -log_file_max_size uint
- -logtostderr
- -skip_headers
- -skip_log_headers
- -stderrthreshold value
- -v value
- -vmodule value

After fix this,  byoh-hostagent only has the following flags:
- -downloadpath string
- -kubeconfig string
- -label value
- -metricsbindaddress string
- -namespace string
- -skip-installation

Plus, In order to avoid such a bug again, I add a test for --help command. Any unexpected option will caused the test failure.