### PR TITLE
e2e test with installer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ RELEASE_DIR := _dist
 # Image URL to use all building/pushing image targets
 IMG ?= ${STAGING_REGISTRY}/${IMAGE_NAME}:${TAG}
 BYOH_BASE_IMG = byoh/node:v1.22.3
+BYOH_BASE_IMG_DEV = byoh-dev/node:v1.22.3
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 
@@ -110,6 +111,9 @@ docker-push: ## Push docker image with the manager.
 
 prepare-byoh-docker-host-image:
 	docker build test/e2e -f test/e2e/BYOHDockerFile -t ${BYOH_BASE_IMG}
+
+prepare-byoh-docker-host-image-dev:
+	docker build test/e2e -f docs/BYOHDockerFileDev -t ${BYOH_BASE_IMG_DEV}
 
 test-e2e: docker-build prepare-byoh-docker-host-image $(GINKGO) cluster-templates ## Run the end-to-end tests
 	CONTROL_PLANE_ENDPOINT_IP=172.18.10.151 $(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \

--- a/docs/BYOHDockerFileDev
+++ b/docs/BYOHDockerFileDev
@@ -1,0 +1,28 @@
+ARG BASE_IMAGE=ubuntu:20.04
+FROM $BASE_IMAGE as build
+ARG TARGETARCH
+# install containerd
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        systemd conntrack iptables iproute2 ethtool socat util-linux mount \
+        ebtables kmod libseccomp2 pigz bash ca-certificates \
+        rsync nfs-common fuse-overlayfs containerd curl gnupg2 \
+    && mkdir -p /etc/containerd \
+    && containerd config default | tee /etc/containerd/config.toml \
+    && ln -s "$(which systemd)" /sbin/init
+RUN  systemctl enable containerd
+COPY kubernetes.list /etc/apt/sources.list.d/kubernetes.list
+RUN echo "Installing kubectl kubeadm kubelet" \
+    && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+    && apt-get update \
+    && apt-get install -y linux-image-$(uname -r) \
+    && apt-get install -y kubelet=1.22.3-00 kubeadm=1.22.3-00 kubectl=1.22.3-00 \
+    && apt-mark hold containerd kubelet kubeadm kubectl \
+    && apt-get clean \
+    && systemctl enable kubelet.service \
+    && systemctl enable containerd.service
+
+FROM scratch
+COPY --from=build / /
+
+ENTRYPOINT ["/sbin/init"]

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -81,7 +81,7 @@ If not, you could create containers to deploy your workload clusters on. We have
 
 ```shell
 cd cluster-api-provider-bringyourownhost
-make prepare-byoh-docker-host-image
+make prepare-byoh-docker-host-image-dev
 ```
 
 Once the image is ready, lets start 2 docker containers for our deployment. One for the control plane, and one for the worker. (you could of course run more)

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -94,7 +94,7 @@ make host-agent-binaries
 ### Create docker hosts
 ```shell
 cd cluster-api-provider-bringyourownhost
-make prepare-byoh-docker-host-image
+make prepare-byoh-docker-host-image-dev
 ```
 Run the following to create n hosts, where ```n>1```
 ```shell

--- a/test/e2e/BYOHDockerFile
+++ b/test/e2e/BYOHDockerFile
@@ -1,26 +1,14 @@
 ARG BASE_IMAGE=ubuntu:20.04
 FROM $BASE_IMAGE as build
 ARG TARGETARCH
-# install containerd
+
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-       systemd conntrack iptables iproute2 ethtool socat util-linux mount \
-       ebtables kmod libseccomp2 pigz bash ca-certificates \
-       rsync nfs-common fuse-overlayfs containerd curl gnupg2\
-    && mkdir -p /etc/containerd \
-    && containerd config default | tee /etc/containerd/config.toml \
+        systemd conntrack iptables iproute2 ethtool socat util-linux mount \
+        ebtables kmod libseccomp2 pigz bash ca-certificates \
+        rsync nfs-common fuse-overlayfs curl gnupg2 \
+        dbus ufw linux-image-$(uname -r) \
     && ln -s "$(which systemd)" /sbin/init
-RUN  systemctl enable containerd
-COPY kubernetes.list /etc/apt/sources.list.d/kubernetes.list
-RUN echo "Installing kubectl kubeadm kubelet" \
-    && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
-    && apt-get update \
-    && apt-get install -y linux-image-$(uname -r) \
-    && apt-get install -y kubelet=1.22.3-00 kubeadm=1.22.3-00 kubectl=1.22.3-00 \
-    && apt-mark hold containerd kubelet kubeadm kubectl \
-    && apt-get clean \
-    && systemctl enable kubelet.service \
-    && systemctl enable containerd.service
 
 FROM scratch
 COPY --from=build / /

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -191,7 +191,7 @@ func setupByoDockerHost(ctx context.Context, clusterConName, byoHostName, namesp
 	rconfig := types.ExecConfig{
 		AttachStdout: true,
 		AttachStderr: true,
-		Cmd:          []string{"./agent", "--kubeconfig", "/mgmt.conf", "--namespace", namespace, "--skip-installation"},
+		Cmd:          []string{"./agent", "--kubeconfig", "/mgmt.conf", "--namespace", namespace},
 	}
 
 	resp, err := dockerClient.ContainerExecCreate(ctx, byohost.ID, rconfig)


### PR DESCRIPTION
**What this PR does / why we need it**:
- removed the `skip-installation` flag from e2e test
- updated `test/e2e/BYOHDockerfile` to **exclude** k8s components
- added a few additional required packages (`ufw` and `dbus`) to the Dockerfile
- added a new dev-dockerfile to continue having the same experience in
  getting started and local-dev guides

Successful e2e run: https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/runs/4800081237?check_suite_focus=true

**Notes for Reviewer:**
Adding additional Dockerfile so that the current getting started guides are not affected by this change. This PR's aim is to enable running e2e tests in GH Actions without skipping the installer workflow. Currently, the getting started guides skip this step and we want to continue doing that until we figure out a better way to not modify host config or some other alternative.