### PR TITLE
Added code coverage report generation and upload to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,14 @@ jobs:
         go-version: 1.16
 
     - name: Install ginkgo
-      run: sudo apt-get install golang-ginkgo-dev
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
     - name: Run test make target
       run: make test
+
+    - name: Upload test coverage
+      uses: codecov/codecov-action@v2
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: cover.out
+        verbose: true 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,10 @@ all: build
 HOST_AGENT_DIR ?= agent
 
 # Run tests
-test: generate fmt vet manifests controller-test agent-test webhook-test
+test: generate fmt vet manifests test-coverage webhook-test
+
+test-coverage:
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test,apis .
 
 agent-test:
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out


### PR DESCRIPTION
**What this PR does / why we need it**:
This will provide continuous test code coverage for `BYOH`.  The step `apt-get install golang-ginkgo-dev` installs version `1.2.0` which does not handle the creation of code coverage report, hence the command is updated to `go get`

- Code coverage for unit/integration tests
- Secret is added for integration to `codecov`
- `e2e` and `webhook` tests are skipped

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #309 

**Additional information**
A successful run on my fork is https://github.com/dharmjit/cluster-api-provider-bringyourownhost/runs/4813076281?check_suite_focus=true and code coverage can be seen here https://app.codecov.io/gh/dharmjit/cluster-api-provider-bringyourownhost/

**Special notes for your reviewer**
Webhook tests are excluded from test coverage currently and will be included in subsequent PR as we need to figure out how to remove some specific files only. 