### PR TITLE
Add a script to run e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,4 +26,4 @@ jobs:
       run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
 
     - name: Run PR-Blocking e2e tests
-      run: GINKGO_FOCUS="\[PR-Blocking\]" make test-e2e
+      run: yes | make test-e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,4 +26,4 @@ jobs:
       run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
 
     - name: Run PR-Blocking e2e tests
-      run: yes | make test-e2e
+      run: yes | GINKGO_FOCUS="\[PR-Blocking\]" make test-e2e

--- a/agent/installer/internal/algo/installer.go
+++ b/agent/installer/internal/algo/installer.go
@@ -31,8 +31,8 @@ are required in order to:
 2) create a systemwide config that will enable those modules at boot time
 3) enable ipv4 & ipv6 forwarding
 4) create a systemwide config that will enable the forwarding at boot time
-5) realod the sysctl with the applied config changes so the changes can take
-   effect without restarting
+5) reload the sysctl with the applied config changes so the changes can take
+	effect without restarting
 6) disable unattended OS updates
 */
 


### PR DESCRIPTION
**What this PR does / why we need it**:
- the make target warns the user of the potential kernel config changes if
  run locally
- if the user selects yes, then proceed to run only quickstart e2e
  test
- we will run the test by default in CI

Quoting the warning info from here - 
https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/blob/072890aadd636575b119c37d53d28d96983baf26/agent/installer/internal/algo/installer.go#L30-L36


Fixes #231 

