### PR TITLE
fix bug: Got error: Node \"node02\" is invalid: spec.providerID: Forbidden: node updates may not change providerID except from \"\" to valid 

### DIFF
--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -360,7 +360,8 @@ func (r *ByoMachineReconciler) setNodeProviderID(ctx context.Context, remoteClie
 	}
 
 	if node.Spec.ProviderID != "" {
-		match, err := regexp.MatchString("byoh://"+host.Name+"/.+", node.Spec.ProviderID)
+		var match bool
+		match, err = regexp.MatchString("byoh://"+host.Name+"/.+", node.Spec.ProviderID)
 		if err != nil {
 			return "", err
 		}

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -375,7 +375,7 @@ func (r *ByoMachineReconciler) setNodeProviderID(ctx context.Context, remoteClie
 		return "", err
 	}
 
-	node.Spec.ProviderID = fmt.Sprintf("%s%s/%s", providerIDPrefix, host.Name, util.RandomString(providerIDSuffixLength))
+	node.Spec.ProviderID = fmt.Sprintf("%s%s/%s", ProviderIDPrefix, host.Name, util.RandomString(providerIDSuffixLength))
 
 	return node.Spec.ProviderID, helper.Patch(ctx, node)
 }

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -360,7 +360,7 @@ func (r *ByoMachineReconciler) setNodeProviderID(ctx context.Context, remoteClie
 
 	if node.Spec.ProviderID != "" {
 		var match bool
-		match, err = regexp.MatchString("byoh://"+host.Name+"/.+", node.Spec.ProviderID)
+		match, err = regexp.MatchString(fmt.Sprintf("%s%s/.+", ProviderIDPrefix, host.Name), node.Spec.ProviderID)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Fixes #290

This issue is not easy to reproduce, and I only met once. It is triggered when the following scenario happened:
In the reconcile function of the byomachine:
    1) The first time to set “Updating Node with ProviderID” return failed with timeout, but actually the node object “node02" already update with spec.ProviderID “byoh://node02/hg7i3d”.
    2) Then every time after “Updating Node with ProviderID” return failed with Node “node02” is invalid: spec.providerID: Forbidden: node updates may not change providerID except from “” to valid”
This is because it is not allowed to update the spec.providerID of node object. This error prevent the continuation of reconcile. And If this happened, it need to remove the node from the cluster manually and restart kubelet on it.

I open this issue to track it, and I was thinking of a solution which may fix the issue without manual operation:
Inside the setNodeProviderID function, if field is not empty and equal to providerID, then skip patch.
If not empty and not equal to providerID, then throw a custom error message cannot set providerID on the node.

