### PR TITLE
Added codecov badge in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
 # Kubernetes Cluster API Provider BYOH(Bring your own host)
 <p align="center">
-<!-- lint card --><a href="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/lint.yml" width="160x">
-<img src="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/lint.yml/badge.svg" width="160x"></a>
+<!-- lint card --><a href="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/lint.yml">
+<img src="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/lint.yml/badge.svg"></a>
 <!-- test status -->
-<a href="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/main.yml" width="160x">
-<img src="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/main.yml/badge.svg" width="200x"></a>
+<a href="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/main.yml">
+<img src="https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/actions/workflows/main.yml/badge.svg"></a>
 <!-- go doc / reference card -->
-<a href="https://pkg.go.dev/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost"  width="160x">
-<img src="https://pkg.go.dev/badge/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost.svg"  width="100x"></a>
+<a href="https://pkg.go.dev/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost">
+<img src="https://pkg.go.dev/badge/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost.svg"></a>
 <!-- goreportcard badge -->
-<a href="https://goreportcard.com/report/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost"  width="160x">
-<img src="https://goreportcard.com/badge/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost"  width="100x"></a>
+<a href="https://goreportcard.com/report/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost">
+<img src="https://goreportcard.com/badge/github.com/vmware-tanzu/cluster-api-provider-bringyourownhost"></a>
+<!-- codecov badge -->
+<a href="https://codecov.io/gh/vmware-tanzu/cluster-api-provider-bringyourownhost">
+<img src="https://codecov.io/gh/vmware-tanzu/cluster-api-provider-bringyourownhost/branch/main/graph/badge.svg?token=8GGPY0MENQ"></a>    
 </p>
 
 ------


### PR DESCRIPTION
Now as we have continuous test coverage with PR #317, It would be useful to see the results in the repo itself. This PR will
- Add code coverage badge in the `README.md` file
- Remove width attribute from `anchor/image` html elements for badges

**What this PR does / why we need it**:
To see the test code coverage in the repo readme.

**Which issue(s) this PR fixes** :
Fixes #264 

**Additional information** 
The width attribute is removed for badge HTML elements as maintaining dimensions could be complex/different for each badge, Instead we are going with standard sizes.

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->