### PR TITLE
Bump ginkgo version in gh actions workflows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
         go-version: 1.16
 
     - name: Install ginkgo
-      run: sudo apt-get install golang-ginkgo-dev
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
     - name: turn off swap
       run: sudo swapoff -a

--- a/.github/workflows/test-agent.yml
+++ b/.github/workflows/test-agent.yml
@@ -32,7 +32,7 @@ jobs:
           go-version: 1.16
 
       - name: Install ginkgo
-        run: sudo apt-get install golang-ginkgo-dev
+        run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
       - name: make sure it has permission to clean up directory
         run: sudo chmod -R 755 /etc

--- a/.github/workflows/test-controller.yml
+++ b/.github/workflows/test-controller.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: 1.16
 
     - name: Install ginkgo
-      run: sudo apt-get install golang-ginkgo-dev
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
     - name: test byoh controllers
       run: make controller-test

--- a/.github/workflows/test-webhook.yml
+++ b/.github/workflows/test-webhook.yml
@@ -18,7 +18,7 @@ jobs:
         go-version: 1.16
 
     - name: Install ginkgo
-      run: sudo apt-get install golang-ginkgo-dev
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
     - name: test byoh webhook
       run: make webhook-test


### PR DESCRIPTION
Ginkgo Installation command is updated to `go get` in all gh actions workflows as `apt-get` command is installing an older version `v1.2.0` 

**Which issue(s) this PR fixes** :
Fixes #327 
