### PR TITLE
Bugfix kubeadm cleanup

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -196,72 +196,23 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 		if err != nil {
 			return err
 		}
-	} else {
-		logger.Info("Skipping k8s node reset")
-	}
-
-	if r.SkipInstallation {
-		logger.Info("Skipping uninstallation of k8s components")
-	} else {
-		bundleRegistry := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation]
-		k8sVersion := byoHost.GetAnnotations()[infrastructurev1beta1.K8sVersionAnnotation]
-		byohBundleTag := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupTagAnnotation]
-		bundleInstaller, err := installer.New(bundleRegistry, r.DownloadPath, logger)
-		if err != nil {
-			return err
-		}
-		err = bundleInstaller.Uninstall(k8sVersion, byohBundleTag)
-		if err != nil {
-			logger.Info(err.Error())
-			return err
-		}
-	}
-
-	conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
-
-	logger.Info("Removing the bootstrap sentinel file...")
-	if _, err := os.Stat(bootstrapSentinelFile); !os.IsNotExist(err) {
-		err := os.Remove(bootstrapSentinelFile)
-		if err != nil {
-			return errors.Wrapf(err, "failed to delete sentinel file %s", bootstrapSentinelFile)
-		}
-	}
-	if IP, ok := byoHost.Annotations[infrastructurev1beta1.EndPointIPAnnotation]; ok {
-		network, err := vip.NewConfig(IP, registration.LocalHostRegistrar.ByoHostInfo.DefaultNetworkInterfaceName, false)
-		if err == nil {
-			err := network.DeleteIP()
+		if r.SkipInstallation {
+			logger.Info("Skipping uninstallation of k8s components")
+		} else {
+			err = r.uninstallk8sComponents(ctx, byoHost)
 			if err != nil {
 				return err
 			}
 		}
+	} else {
+		logger.Info("Skipping k8s node reset and k8s component uninstallation")
 	}
-	// Remove host reservation
-	byoHost.Status.MachineRef = nil
+	conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 
-	// Remove BootstrapSecret
-	byoHost.Spec.BootstrapSecret = nil
-
-	// Remove cluster-name label
-	delete(byoHost.Labels, clusterv1.ClusterLabelName)
-
-	// Remove Byomachine-name label
-	delete(byoHost.Labels, infrastructurev1beta1.AttachedByoMachineLabel)
-
-	// Remove the EndPointIP annotation
-	delete(byoHost.Annotations, infrastructurev1beta1.EndPointIPAnnotation)
-
-	// Remove the cleanup annotation
-	delete(byoHost.Annotations, infrastructurev1beta1.HostCleanupAnnotation)
-
-	// Remove the cluster version annotation
-	delete(byoHost.Annotations, infrastructurev1beta1.K8sVersionAnnotation)
-
-	// Remove the bundle registry annotation
-	delete(byoHost.Annotations, infrastructurev1beta1.BundleLookupBaseRegistryAnnotation)
-
-	// Remove the bundle tag annotation
-	delete(byoHost.Annotations, infrastructurev1beta1.BundleLookupTagAnnotation)
-
+	err := r.removeAnnotations(ctx, byoHost)
+	if err != nil {
+		return err
+	}
 	conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 	return nil
 }
@@ -307,5 +258,69 @@ func (r *HostReconciler) installK8sComponents(ctx context.Context, byoHost *infr
 
 	r.Recorder.Event(byoHost, corev1.EventTypeNormal, "k8sComponentInstalled", "Successfully Installed K8s components")
 	conditions.MarkTrue(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+	return nil
+}
+
+func (r *HostReconciler) uninstallk8sComponents(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
+	logger := ctrl.LoggerFrom(ctx)
+	
+	bundleRegistry := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation]
+	k8sVersion := byoHost.GetAnnotations()[infrastructurev1beta1.K8sVersionAnnotation]
+	byohBundleTag := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupTagAnnotation]
+	bundleInstaller, err := installer.New(bundleRegistry, r.DownloadPath, logger)
+	if err != nil {
+		return err
+	}
+	err = bundleInstaller.Uninstall(k8sVersion, byohBundleTag)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
+	logger := ctrl.LoggerFrom(ctx)
+	logger.Info("Removing the bootstrap sentinel file...")
+	if _, err := os.Stat(bootstrapSentinelFile); !os.IsNotExist(err) {
+		err := os.Remove(bootstrapSentinelFile)
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete sentinel file %s", bootstrapSentinelFile)
+		}
+	}
+	if IP, ok := byoHost.Annotations[infrastructurev1beta1.EndPointIPAnnotation]; ok {
+		network, err := vip.NewConfig(IP, registration.LocalHostRegistrar.ByoHostInfo.DefaultNetworkInterfaceName, false)
+		if err == nil {
+			err := network.DeleteIP()
+			if err != nil {
+				return err
+			}
+		}
+	}
+	// Remove host reservation
+	byoHost.Status.MachineRef = nil
+
+	// Remove BootstrapSecret
+	byoHost.Spec.BootstrapSecret = nil
+
+	// Remove cluster-name label
+	delete(byoHost.Labels, clusterv1.ClusterLabelName)
+
+	// Remove Byomachine-name label
+	delete(byoHost.Labels, infrastructurev1beta1.AttachedByoMachineLabel)
+
+	// Remove the EndPointIP annotation
+	delete(byoHost.Annotations, infrastructurev1beta1.EndPointIPAnnotation)
+
+	// Remove the cleanup annotation
+	delete(byoHost.Annotations, infrastructurev1beta1.HostCleanupAnnotation)
+
+	// Remove the cluster version annotation
+	delete(byoHost.Annotations, infrastructurev1beta1.K8sVersionAnnotation)
+
+	// Remove the bundle registry annotation
+	delete(byoHost.Annotations, infrastructurev1beta1.BundleLookupBaseRegistryAnnotation)
+
+	// Remove the bundle tag annotation
+	delete(byoHost.Annotations, infrastructurev1beta1.BundleLookupTagAnnotation)
 	return nil
 }

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -219,10 +219,7 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 		return err
 	}
 
-	err = r.removeAnnotations(ctx, byoHost)
-	if err != nil {
-		return err
-	}
+	r.removeAnnotations(ctx, byoHost)
 	conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
 	return nil
 }
@@ -315,7 +312,7 @@ func (r *HostReconciler) deleteEndpointIP(ctx context.Context, byoHost *infrastr
 	return nil
 }
 
-func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
+func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) {
 	logger := ctrl.LoggerFrom(ctx)
 	logger.Info("Removing annotations")
 	// Remove host reservation
@@ -344,5 +341,4 @@ func (r *HostReconciler) removeAnnotations(ctx context.Context, byoHost *infrast
 
 	// Remove the bundle tag annotation
 	delete(byoHost.Annotations, infrastructurev1beta1.BundleLookupTagAnnotation)
-	return nil
 }

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -323,7 +323,21 @@ runCmd:
 					infrastructurev1beta1.BundleLookupTagAnnotation:          "byoh-bundle-tag",
 				}
 				conditions.MarkTrue(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded)
+				conditions.MarkTrue(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
 				Expect(patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).NotTo(HaveOccurred())
+			})
+
+			It("should skip node reset if k8s component installation failed", func() {
+				conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sComponentsInstallationFailedReason, clusterv1.ConditionSeverityInfo, "")
+				result, reconcilerErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
+					NamespacedName: byoHostLookupKey,
+				})
+				Expect(result).To(Equal(controllerruntime.Result{}))
+				Expect(reconcilerErr).ToNot(HaveOccurred())
+
+				// assert kubeadm reset is not called
+				Expect(fakeCommandRunner.RunCmdCallCount()).To(Equal(0))
+
 			})
 
 			It("should reset the node and set the Reason to K8sNodeAbsentReason", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix node clean-up logic to skip node reset in case the k8s installation fails

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #298 