### PR TITLE
should ignore some dirs' codecov

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -6,3 +6,8 @@ comment:                  # this is a top-level key
 ignore:
 - "test"
 - "apis"
+- "scripts"
+- "hack"
+- "docs"
+- "config"
+- "common"


### PR DESCRIPTION
Ignore them can improve our codecov from  62% to 68.5%.

Signed-off-by: chen hui <huchen@vmware.com>
