### PR TITLE
Add pre-requisite package precheck to byoh-agent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on:
   push:
     branches: [ main ]
   pull_request:
-    branches: [ main ]    
+    branches: [ main ]
 
 jobs:
-  build-agent:  
+  build-agent:
       runs-on: ubuntu-latest
       steps:
       - name: Checkout code
@@ -35,6 +35,9 @@ jobs:
     - name: Install ginkgo
       run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
+    - name: Install prequisit packages
+      run: sudo apt update && sudo apt install -qq --yes socat ebtables ethtool conntrack
+
     - name: Run test make target
       run: make test
 
@@ -43,4 +46,4 @@ jobs:
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: cover.out
-        verbose: true 
+        verbose: true

--- a/agent/installer/checks.go
+++ b/agent/installer/checks.go
@@ -1,0 +1,42 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package installer
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/go-logr/logr"
+	utilsexec "k8s.io/utils/exec"
+)
+
+func checkPreRequsitePackages() error {
+	if runtime.GOOS == "linux" {
+		unavailablePackages := []string{}
+		execr := utilsexec.New()
+		for _, pkgName := range preRequisitePackages {
+			_, err := execr.LookPath(pkgName)
+			if err != nil {
+				unavailablePackages = append(unavailablePackages, pkgName)
+			}
+		}
+		if len(unavailablePackages) != 0 {
+			return fmt.Errorf("required package(s): %s not found", unavailablePackages)
+		}
+		return nil
+	}
+	return nil
+}
+
+func runPrechecks(logger logr.Logger, os string) bool {
+	precheckSuccessful := true
+
+	// verify that packages are available when user has chosen to install kubernetes binaries
+	err := checkPreRequsitePackages()
+	if err != nil {
+		logger.Error(err, "Failed pre-requisite packages precheck")
+		precheckSuccessful = false
+	}
+	return precheckSuccessful
+}

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -130,7 +130,7 @@ func runPrechecks(logger logr.Logger, os string) bool {
 	}
 
 	// verify that packages are available when user has chosen to install kubernetes binaries
-	err = preckeckPreRequsitPackages()
+	err = ckeckPreRequsitePackages()
 	if err != nil {
 		logger.Error(err, "Failed pre-requisite packages precheck")
 		precheckSuccessful = false

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -98,8 +98,7 @@ func ckeckPreRequsitePackages() error {
 		}
 	}
 	if len(unavailablePackages) != 0 {
-		errMsg := fmt.Sprintf("Required package(s): %s not found", unavailablePackages)
-		return errors.New(errMsg)
+		return fmt.Errorf("required package(s): %s not found", unavailablePackages)
 	}
 	return nil
 }

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -132,7 +132,7 @@ func runPrechecks(logger logr.Logger, os string) bool {
 	// verify that packages are available when user has chosen to install kubernetes binaries
 	err = preckeckPreRequsitPackages()
 	if err != nil {
-		logger.Error(err, "Failed pre-requisit packages precheck")
+		logger.Error(err, "Failed pre-requisite packages precheck")
 		precheckSuccessful = false
 	}
 	return precheckSuccessful

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -6,10 +6,7 @@ package installer
 import (
 	"errors"
 	"fmt"
-	"runtime"
 	"strings"
-
-	utilsexec "k8s.io/utils/exec"
 
 	"github.com/go-logr/logr"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/installer/internal/algo"
@@ -89,36 +86,6 @@ func (bd *bundleDownloader) DownloadOrPreview(os, k8s, tag string) error {
 	}
 
 	return bd.Download(os, k8s, tag)
-}
-
-func ckeckPreRequsitePackages() error {
-	if runtime.GOOS == "linux" {
-		unavailablePackages := []string{}
-		execr := utilsexec.New()
-		for _, pkgName := range preRequisitePackages {
-			_, err := execr.LookPath(pkgName)
-			if err != nil {
-				unavailablePackages = append(unavailablePackages, pkgName)
-			}
-		}
-		if len(unavailablePackages) != 0 {
-			return fmt.Errorf("required package(s): %s not found", unavailablePackages)
-		}
-		return nil
-	}
-	return nil
-}
-
-func runPrechecks(logger logr.Logger, os string) bool {
-	precheckSuccessful := true
-
-	// verify that packages are available when user has chosen to install kubernetes binaries
-	err := ckeckPreRequsitePackages()
-	if err != nil {
-		logger.Error(err, "Failed pre-requisite packages precheck")
-		precheckSuccessful = false
-	}
-	return precheckSuccessful
 }
 
 // New returns an installer that downloads bundles for the current OS from OCI repository with

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -103,7 +103,7 @@ func supportedOSversion(os string) error {
 	return nil
 }
 
-func preckeckPreRequsitPackages() error {
+func ckeckPreRequsitePackages() error {
 	unavailablePackages := []string{}
 	for _, pkgName := range PreRequisitePackages {
 		_, err := exec.Command("dpkg-query", "-W", pkgName).Output()

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -25,7 +24,6 @@ const (
 	ErrBundleExtract     = Error("Error extracting bundle")
 	ErrBundleInstall     = Error("Error installing bundle")
 	ErrBundleUninstall   = Error("Error uninstalling bundle")
-	SupportedOS          = "Ubuntu_20.04.*_x86-64"
 )
 
 var PreRequisitePackages = []string{"socat", "ebtables", "ethtool", "conntrack"}
@@ -91,18 +89,6 @@ func (bd *bundleDownloader) DownloadOrPreview(os, k8s, tag string) error {
 	return bd.Download(os, k8s, tag)
 }
 
-func supportedOSversion(os string) error {
-	matched, err := regexp.Match(SupportedOS, []byte(os))
-	if err != nil {
-		return err
-	}
-	if !matched {
-		errMsg := fmt.Sprintf("Unsupported OS. Note: Currently supported OS is %s", SupportedOS)
-		return errors.New(errMsg)
-	}
-	return nil
-}
-
 func ckeckPreRequsitePackages() error {
 	unavailablePackages := []string{}
 	for _, pkgName := range PreRequisitePackages {
@@ -121,16 +107,8 @@ func ckeckPreRequsitePackages() error {
 func runPrechecks(logger logr.Logger, os string) bool {
 	precheckSuccessful := true
 
-	// BYOH Agent is currently only supported on Ubuntu 20.04.x
-	// This precheck verifies
-	err := supportedOSversion(os)
-	if err != nil {
-		logger.Error(err, "Failed supported OS version precheck")
-		precheckSuccessful = false
-	}
-
 	// verify that packages are available when user has chosen to install kubernetes binaries
-	err = ckeckPreRequsitePackages()
+	err := ckeckPreRequsitePackages()
 	if err != nil {
 		logger.Error(err, "Failed pre-requisite packages precheck")
 		precheckSuccessful = false

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -26,7 +26,7 @@ const (
 	ErrBundleUninstall   = Error("Error uninstalling bundle")
 )
 
-var PreRequisitePackages = []string{"socat", "ebtables", "ethtool", "conntrack"}
+var preRequisitePackages = []string{"socat", "ebtables", "ethtool", "conntrack"}
 
 type installer struct {
 	algoRegistry registry
@@ -91,7 +91,7 @@ func (bd *bundleDownloader) DownloadOrPreview(os, k8s, tag string) error {
 
 func ckeckPreRequsitePackages() error {
 	unavailablePackages := []string{}
-	for _, pkgName := range PreRequisitePackages {
+	for _, pkgName := range preRequisitePackages {
 		_, err := exec.Command("dpkg-query", "-W", pkgName).Output()
 		if err != nil {
 			unavailablePackages = append(unavailablePackages, pkgName)

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -122,40 +122,6 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(func() { NewPreviewInstaller("Ubuntu_20.04.3_x86-64", nil) }).NotTo(Panic())
 		})
 	})
-	Context("When available packages are checked for PreRequisitPackages", func() {
-		var preRequisitPackagesBackup []string
-		BeforeEach(func() {
-			// Setting pre requisits as some packages that would definitely be present on any ubuntu version
-			preRequisitPackagesBackup = PreRequisitePackages
-			PreRequisitePackages = []string{"apt", "cron"}
-		})
-
-		AfterEach(func() {
-			PreRequisitePackages = preRequisitPackagesBackup
-		})
-
-		It("Should not return error", func() {
-			_, err := New("repo", "downloadPath", logr.Discard())
-			Expect(err).ShouldNot((HaveOccurred()))
-		})
-	})
-	Context("When unavailable packages are checked for PreRequisitPackages", func() {
-		var preRequisitPackagesBackup []string
-		BeforeEach(func() {
-			// Setting pre requisits as some packages that would definitely be present on any ubuntu version
-			preRequisitPackagesBackup = PreRequisitePackages
-			PreRequisitePackages = []string{"dummy_package_name"}
-		})
-
-		AfterEach(func() {
-			PreRequisitePackages = preRequisitPackagesBackup
-		})
-
-		It("Should return error", func() {
-			_, err := New("repo", "downloadPath", logr.Discard())
-			Expect(err).Should((HaveOccurred()))
-		})
-	})
 })
 
 func NewPreviewInstaller(os string, ob algo.OutputBuilder) *installer {

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -122,18 +122,6 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(func() { NewPreviewInstaller("Ubuntu_20.04.3_x86-64", nil) }).NotTo(Panic())
 		})
 	})
-	Context("When supported OS version is passed for precheck", func() {
-		It("Should not return error", func() {
-			err := supportedOSversion("Ubuntu_20.04.1_x86-64")
-			Expect(err).ShouldNot((HaveOccurred()))
-		})
-	})
-	Context("When unsupported OS version is passed for precheck", func() {
-		It("Should return an error", func() {
-			err := supportedOSversion("dummy_os")
-			Expect(err).Should(HaveOccurred())
-		})
-	})
 	Context("When available packages are checked for PreRequisitPackages", func() {
 		var preRequisitPackagesBackup []string
 		BeforeEach(func() {
@@ -147,7 +135,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 		})
 
 		It("Should not return error", func() {
-			err := preckeckPreRequsitPackages()
+			_, err := New("repo", "downloadPath", logr.Discard())
 			Expect(err).ShouldNot((HaveOccurred()))
 		})
 	})
@@ -164,8 +152,20 @@ var _ = Describe("Byohost Installer Tests", func() {
 		})
 
 		It("Should return error", func() {
-			err := preckeckPreRequsitPackages()
+			_, err := New("repo", "downloadPath", logr.Discard())
 			Expect(err).Should((HaveOccurred()))
+		})
+	})
+	Context("When supported OS version is passed for precheck", func() {
+		It("Should not return error", func() {
+			err := supportedOSversion("Ubuntu_20.04.1_x86-64")
+			Expect(err).ShouldNot((HaveOccurred()))
+		})
+	})
+	Context("When unsupported OS version is passed for precheck", func() {
+		It("Should return an error", func() {
+			err := supportedOSversion("dummy_os")
+			Expect(err).Should(HaveOccurred())
 		})
 	})
 })

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -156,18 +156,6 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(err).Should((HaveOccurred()))
 		})
 	})
-	Context("When supported OS version is passed for precheck", func() {
-		It("Should not return error", func() {
-			err := supportedOSversion("Ubuntu_20.04.1_x86-64")
-			Expect(err).ShouldNot((HaveOccurred()))
-		})
-	})
-	Context("When unsupported OS version is passed for precheck", func() {
-		It("Should return an error", func() {
-			err := supportedOSversion("dummy_os")
-			Expect(err).Should(HaveOccurred())
-		})
-	})
 })
 
 func NewPreviewInstaller(os string, ob algo.OutputBuilder) *installer {

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -122,6 +122,52 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(func() { NewPreviewInstaller("Ubuntu_20.04.3_x86-64", nil) }).NotTo(Panic())
 		})
 	})
+	Context("When supported OS version is passed for precheck", func() {
+		It("Should not return error", func() {
+			err := supportedOSversion("Ubuntu_20.04.1_x86-64")
+			Expect(err).ShouldNot((HaveOccurred()))
+		})
+	})
+	Context("When unsupported OS version is passed for precheck", func() {
+		It("Should return an error", func() {
+			err := supportedOSversion("dummy_os")
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+	Context("When available packages are checked for PreRequisitPackages", func() {
+		var preRequisitPackagesBackup []string
+		BeforeEach(func() {
+			// Setting pre requisits as some packages that would definitely be present on any ubuntu version
+			preRequisitPackagesBackup = PreRequisitePackages
+			PreRequisitePackages = []string{"apt", "cron"}
+		})
+
+		AfterEach(func() {
+			PreRequisitePackages = preRequisitPackagesBackup
+		})
+
+		It("Should not return error", func() {
+			err := preckeckPreRequsitPackages()
+			Expect(err).ShouldNot((HaveOccurred()))
+		})
+	})
+	Context("When unavailable packages are checked for PreRequisitPackages", func() {
+		var preRequisitPackagesBackup []string
+		BeforeEach(func() {
+			// Setting pre requisits as some packages that would definitely be present on any ubuntu version
+			preRequisitPackagesBackup = PreRequisitePackages
+			PreRequisitePackages = []string{"dummy_package_name"}
+		})
+
+		AfterEach(func() {
+			PreRequisitePackages = preRequisitPackagesBackup
+		})
+
+		It("Should return error", func() {
+			err := preckeckPreRequsitPackages()
+			Expect(err).Should((HaveOccurred()))
+		})
+	})
 })
 
 func NewPreviewInstaller(os string, ob algo.OutputBuilder) *installer {


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently we only support byoh-agent on Ubuntu 20.04.x
Also when the user doesn't choose to skip installation for kubernetes
component binaries, following packages are expected to be pre-installed:
socat, ebtables, ethtool, conntrack
Add precheck to verify the above two conditions

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #254 
