### PR TITLE
Add controller tests for paused condition for ByoHost

### DIFF
--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 					Expect(createdByoHost.Annotations).To(HaveKey(clusterv1.PausedAnnotation))
 				})
 
-				It("should set paused status of host to false", func() {
+				It("should set paused status of byohost to false when byomachine is not paused", func() {
 
 					ph, err := patch.NewHelper(byoHost, k8sClientUncached)
 					Expect(err).ShouldNot(HaveOccurred())

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -270,26 +270,6 @@ var _ = Describe("Controllers/ByomachineController", func() {
 				Expect(node.Spec.ProviderID).To(ContainSubstring(controllers.ProviderIDPrefix))
 			})
 
-			It("should mark host as paused when the ByoMachine is paused", func() {
-				ph, err := patch.NewHelper(byoMachine, k8sClientUncached)
-				Expect(err).ShouldNot(HaveOccurred())
-				pauseAnnotations := map[string]string{
-					clusterv1.PausedAnnotation: "paused",
-				}
-				annotations.AddAnnotations(byoMachine, pauseAnnotations)
-
-				Expect(ph.Patch(ctx, byoMachine, patch.WithStatusObservedGeneration{})).Should(Succeed())
-
-				WaitForObjectToBeUpdatedInCache(byoMachine, func(object client.Object) bool {
-					return annotations.HasPausedAnnotation(object.(*infrastructurev1beta1.ByoMachine))
-				})
-				_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: byoMachineLookupKey})
-				Expect(err).ToNot(HaveOccurred())
-
-				createdByoHost := &infrastructurev1beta1.ByoHost{}
-				Expect(createdByoHost.Annotations[clusterv1.PausedAnnotation]).Should(Equal(""))
-			})
-
 			Context("When ByoMachine is attached to a host", func() {
 				BeforeEach(func() {
 					ph, err := patch.NewHelper(byoHost, k8sClientUncached)
@@ -312,6 +292,27 @@ var _ = Describe("Controllers/ByomachineController", func() {
 					})
 				})
 
+				It("should mark host as paused when the ByoMachine is paused", func() {
+					ph, err := patch.NewHelper(byoMachine, k8sClientUncached)
+					Expect(err).ShouldNot(HaveOccurred())
+					pauseAnnotations := map[string]string{
+						clusterv1.PausedAnnotation: "paused",
+					}
+					annotations.AddAnnotations(byoMachine, pauseAnnotations)
+					Expect(ph.Patch(ctx, byoMachine, patch.WithStatusObservedGeneration{})).Should(Succeed())
+					WaitForObjectToBeUpdatedInCache(byoMachine, func(object client.Object) bool {
+						return annotations.HasPausedAnnotation(object.(*infrastructurev1beta1.ByoMachine))
+					})
+
+					_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: byoMachineLookupKey})
+					Expect(err).ToNot(HaveOccurred())
+
+					createdByoHost := &infrastructurev1beta1.ByoHost{}
+					err = k8sClientUncached.Get(ctx, byoHostLookupKey, createdByoHost)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(createdByoHost.Annotations).To(HaveKey(clusterv1.PausedAnnotation))
+				})
+
 				It("should set paused status of host to false", func() {
 
 					ph, err := patch.NewHelper(byoHost, k8sClientUncached)
@@ -328,6 +329,8 @@ var _ = Describe("Controllers/ByomachineController", func() {
 					_, err = reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: byoMachineLookupKey})
 					Expect(err).ToNot(HaveOccurred())
 					createdByoHost := &infrastructurev1beta1.ByoHost{}
+					err = k8sClientUncached.Get(ctx, byoHostLookupKey, createdByoHost)
+					Expect(err).ToNot(HaveOccurred())
 					Expect(createdByoHost.Annotations).NotTo(HaveKey(clusterv1.PausedAnnotation))
 
 				})


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds unit tests for paused condition handling for ByoHost under two conditions, (a) when the ByoMachine is paused and the host is not paused and (b) when the ByoMachine is not paused and the host is attached but is in paused state.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #338 