### PR TITLE
add cli build details to local_dev docs

### DIFF
--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -259,7 +259,11 @@ docker run --rm -v `pwd`/byoh-ingredients-download:/ingredients -v`pwd`:/bundle 
 ```
 
 ## CLI
-The installer CLI exposes the installer package as a command line tool. For a list of all commands, run
+The installer CLI exposes the installer package as a command line tool. It can be built by running
+```shell
+go build ./agent/installer/cli
+```
+Once built, for a list of all commands, run
 
 ```shell
 ./cli --help


### PR DESCRIPTION
**What this PR does / why we need it**:
Add documentation to `local_dev` on how to build the `cli` binary
