### PR TITLE
Files removed from test code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,10 +55,10 @@ all: build
 HOST_AGENT_DIR ?= agent
 
 # Run tests
-test: generate fmt vet manifests test-coverage webhook-test
+test: generate fmt vet manifests test-coverage
 
 test-coverage:
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test,apis .
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test .
 
 agent-test:
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out

--- a/codecov.yml
+++ b/codecov.yml
@@ -3,6 +3,11 @@ comment:                  # this is a top-level key
   behavior: default
   require_changes: true  # if true: only post the comment if coverage changes
 
+#list of paths (folders or file names) to exclude files from being collected by Codecov
 ignore:
 - "test"
-- "apis"
+- "controllers/infrastructure/byohost_controller.go"
+- "controllers/infrastructure/byomachinetemplate_controller.go"
+- "apis/infrastructure/v1beta1/*_types.go"
+- "apis/infrastructure/v1beta1/zz_generated.deepcopy.go"
+- "agent/installer/cli.go"


### PR DESCRIPTION
- Auto-Generated files or files containing boilerplate code are removed from code coverage.
- Included webhook tests in code coverage

Signed-off-by: Dharmjit Singh <sdharmjit@vmware.com>

**Which issue(s) this PR fixes** :
Fixes #344 

**Additional Information** :
`agent/main.go` is not removed as of now as some of the code related to flags is being tested