### PR TITLE
Fetch control plane IP at runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ prepare-byoh-docker-host-image-dev:
 	docker build test/e2e -f docs/BYOHDockerFileDev -t ${BYOH_BASE_IMG_DEV}
 
 test-e2e: take-user-input docker-build prepare-byoh-docker-host-image $(GINKGO) cluster-templates-e2e ## Run the end-to-end tests
-	CONTROL_PLANE_ENDPOINT_IP=172.18.10.151 $(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \
+	$(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \
 	    -e2e.artifacts-folder="$(ARTIFACTS)" \
 	    -e2e.config="$(E2E_CONF_FILE)" \
 	    -e2e.skip-resource-cleanup=$(SKIP_RESOURCE_CLEANUP) -e2e.use-existing-cluster=$(USE_EXISTING_CLUSTER) \

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -95,6 +95,10 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}()
 
 		By("Creating a cluster")
+		
+		ip := getControlPlaneIp(context.Background(), *dockerClient)
+		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -137,6 +141,10 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+		
+		ip = getControlPlaneIp(context.Background(), *dockerClient)
+		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -96,7 +96,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		By("Creating a cluster")
 		
-		ip := getControlPlaneIp(context.Background(), dockerClient)
+		ip := getControlPlaneIP(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -142,7 +142,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		
-		ip = getControlPlaneIp(context.Background(), dockerClient)
+		ip = getControlPlaneIP(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -140,7 +140,6 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 
-		setControlPlaneIP(context.Background(), dockerClient)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -95,14 +95,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}()
 
 		By("Creating a cluster")
-		
-		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
-		if ok {
-			ip := getControlPlaneIP(context.Background(), dockerClient)
-			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
-		}
 
-
+		setControlPlaneIP(context.Background(), dockerClient)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{
@@ -145,13 +139,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
-		
-		_, ok = os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
-		if ok {
-			ip := getControlPlaneIP(context.Background(), dockerClient)
-			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
-		}
 
+		setControlPlaneIP(context.Background(), dockerClient)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -96,7 +96,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		By("Creating a cluster")
 		
-		ip := getControlPlaneIp(context.Background(), *dockerClient)
+		ip := getControlPlaneIp(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
@@ -142,7 +142,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		
-		ip = getControlPlaneIp(context.Background(), *dockerClient)
+		ip = getControlPlaneIp(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -96,8 +96,12 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		By("Creating a cluster")
 		
-		ip := getControlPlaneIP(context.Background(), dockerClient)
-		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
+		if ok {
+			ip := getControlPlaneIP(context.Background(), dockerClient)
+			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		}
+
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
@@ -142,8 +146,11 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		By("Creating a new cluster")
 		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
 		
-		ip = getControlPlaneIP(context.Background(), dockerClient)
-		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		_, ok = os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
+		if ok {
+			ip := getControlPlaneIP(context.Background(), dockerClient)
+			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		}
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -96,6 +96,7 @@ variables:
   # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.4/clusterctl-{OS}-{ARCH}"
   BUNDLE_LOOKUP_TAG: "v0.1.0_alpha.2"
+  CONTROL_PLANE_ENDPOINT_IP: ""
 
 intervals:
   default/wait-controllers: ["3m", "10s"]

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -9,8 +9,11 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
+	"context"
+	"strings"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
 )
 
 const (
@@ -144,4 +147,12 @@ func ShowInfo(allAgentLogFiles []string) {
 	WriteShellScript(ReadByohControllerManagerLogShellFile, shellContent)
 	ShowFileContent(ReadByohControllerManagerLogShellFile)
 	ExecuteShellScript(ReadByohControllerManagerLogShellFile)
+}
+
+func getControlPlaneIp(ctx context.Context, dockerClient client.Client) string {
+	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
+	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
+	ipOctets[3] = "151"
+	ip := strings.Join(ipOctets, ".")
+	return ip
 }

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -149,7 +149,7 @@ func ShowInfo(allAgentLogFiles []string) {
 	ExecuteShellScript(ReadByohControllerManagerLogShellFile)
 }
 
-func getControlPlaneIp(ctx context.Context, dockerClient *client.Client) string {
+func getControlPlaneIP(ctx context.Context, dockerClient *client.Client) string {
 	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
 	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
 	ipOctets[3] = "151"

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -149,7 +149,7 @@ func ShowInfo(allAgentLogFiles []string) {
 	ExecuteShellScript(ReadByohControllerManagerLogShellFile)
 }
 
-func getControlPlaneIp(ctx context.Context, dockerClient client.Client) string {
+func getControlPlaneIp(ctx context.Context, dockerClient *client.Client) string {
 	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
 	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
 	ipOctets[3] = "151"

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -9,11 +9,8 @@ import (
 	"io/fs"
 	"os"
 	"os/exec"
-	"context"
-	"strings"
 
 	"github.com/docker/docker/api/types"
-	"github.com/docker/docker/client"
 )
 
 const (
@@ -147,12 +144,4 @@ func ShowInfo(allAgentLogFiles []string) {
 	WriteShellScript(ReadByohControllerManagerLogShellFile, shellContent)
 	ShowFileContent(ReadByohControllerManagerLogShellFile)
 	ExecuteShellScript(ReadByohControllerManagerLogShellFile)
-}
-
-func getControlPlaneIP(ctx context.Context, dockerClient *client.Client) string {
-	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
-	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
-	ipOctets[3] = "151"
-	ip := strings.Join(ipOctets, ".")
-	return ip
 }

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 
 	"github.com/docker/cli/cli/command"
 	"github.com/docker/docker/api/types"
@@ -210,4 +211,12 @@ func setupByoDockerHost(ctx context.Context, clusterConName, byoHostName, namesp
 	output, err := dockerClient.ContainerExecAttach(ctx, resp.ID, types.ExecStartCheck{})
 
 	return output, byohost.ID, err
+}
+
+func getControlPlaneIP(ctx context.Context, dockerClient *client.Client) string {
+	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
+	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
+	ipOctets[3] = "151"
+	ip := strings.Join(ipOctets, ".")
+	return ip
 }

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -228,5 +228,4 @@ func setControlPlaneIP(ctx context.Context, dockerClient *client.Client) {
 	ipOctets[3] = "151"
 	ip := strings.Join(ipOctets, ".")
 	os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
-	
 }

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -213,10 +213,13 @@ func setupByoDockerHost(ctx context.Context, clusterConName, byoHostName, namesp
 	return output, byohost.ID, err
 }
 
-func getControlPlaneIP(ctx context.Context, dockerClient *client.Client) string {
-	inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
-	ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
-	ipOctets[3] = "151"
-	ip := strings.Join(ipOctets, ".")
-	return ip
+func setControlPlaneIP(ctx context.Context, dockerClient *client.Client) {
+	_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
+	if !ok {
+		inspect, _ := dockerClient.NetworkInspect(ctx, "kind", types.NetworkInspectOptions{})
+		ipOctets := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
+		ipOctets[3] = "151"
+		ip := strings.Join(ipOctets, ".")
+		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+	}
 }

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -98,10 +97,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		inspect, _ := dockerClient.NetworkInspect(context.Background(), "kind", types.NetworkInspectOptions{})
-		res1 := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
-		res1[3] = "151"
-		ip := strings.Join(res1, ".")
+		ip := getControlPlaneIp(context.Background(), *dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,12 +97,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
-		if ok {
-			ip := getControlPlaneIP(context.Background(), dockerClient)
-			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
-		}
-		
+		setControlPlaneIP(context.Background(), dockerClient)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,7 +97,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		ip := getControlPlaneIp(context.Background(), *dockerClient)
+		ip := getControlPlaneIp(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,8 +97,12 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		ip := getControlPlaneIP(context.Background(), dockerClient)
-		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
+		if ok {
+			ip := getControlPlaneIP(context.Background(), dockerClient)
+			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		}
+		
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/docker/api/types"
 	"github.com/docker/docker/client"
@@ -97,6 +98,11 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
+		inspect, _ := dockerClient.NetworkInspect(context.Background(), "kind", types.NetworkInspectOptions{})
+		res1 := strings.Split(inspect.IPAM.Config[0].Subnet, ".")
+		res1[3] = "151"
+		ip := strings.Join(res1, ".")
+		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -97,7 +97,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		ip := getControlPlaneIp(context.Background(), dockerClient)
+		ip := getControlPlaneIP(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -85,12 +85,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 		By("creating a workload cluster with one control plane node and one worker node")
 		
-		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
-		if ok {
-			ip := getControlPlaneIP(context.Background(), dockerClient)
-			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
-		}
-
+		setControlPlaneIP(context.Background(), dockerClient)
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -85,8 +85,11 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 		By("creating a workload cluster with one control plane node and one worker node")
 		
-		ip := getControlPlaneIP(context.Background(), dockerClient)
-		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		_, ok := os.LookupEnv("CONTROL_PLANE_ENDPOINT_IP")
+		if ok {
+			ip := getControlPlaneIP(context.Background(), dockerClient)
+			os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+		}
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -84,6 +84,10 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		// TODO: Write agent logs to files for better debugging
 
 		By("creating a workload cluster with one control plane node and one worker node")
+		
+		ip := getControlPlaneIp(context.Background(), *dockerClient)
+		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
+
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
 			ClusterProxy: bootstrapClusterProxy,
 			ConfigCluster: clusterctl.ConfigClusterInput{

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -85,7 +85,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 		By("creating a workload cluster with one control plane node and one worker node")
 		
-		ip := getControlPlaneIp(context.Background(), *dockerClient)
+		ip := getControlPlaneIp(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -85,7 +85,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 		By("creating a workload cluster with one control plane node and one worker node")
 		
-		ip := getControlPlaneIp(context.Background(), dockerClient)
+		ip := getControlPlaneIP(context.Background(), dockerClient)
 		os.Setenv("CONTROL_PLANE_ENDPOINT_IP", ip)
 
 		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{


### PR DESCRIPTION
**What this PR does / why we need it**:
Set the `CONTROL_PLANE_ENDPOINT_IP` programmatically at runtime during E2E tests based on docker network settings.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #206 