### PR TITLE
Add Governance details

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,65 @@
+# Cluster API Provider for Bring Your Own Host Governance
+
+This document defines the project governance for Cluster API Provider for Bring Your Own Host.
+
+## Overview
+
+**Cluster API Provider for Bring Your Own Host** is committed to building an open, inclusive, productive and
+self-governing open source community focused on building a high-quality
+[Cluster API Provider](https://cluster-api.sigs.k8s.io/developer/providers/implementers-guide/overview.html). The
+community is governed by this document which defines how all members should work
+together to achieve this goal.
+
+## Code of Conduct
+
+The Bring Your Own Host community abides by this [code of conduct](CODE-OF-CONDUCT.md).
+
+## Community Roles
+
+* **Users:** Members that engage with the Bring Your Own Host community via any medium
+  (Slack, GitHub, mailing lists, etc.).
+* **Contributors:** Do regular contributions to the Bring Your Own Host project
+  (documentation, code reviews, responding to issues, participating in proposal
+  discussions, contributing code, etc.).
+* **Maintainers**: Responsible for the overall health and direction of the
+  project. They are the final reviewers of PRs and responsible for Bring Your Own Host
+  releases.
+
+### Contributors
+
+Anyone can contribute to the project (e.g. open a PR) as long as they follow the
+guidelines in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+
+### Maintainers
+
+The list of current maintainers can be found in
+[MAINTAINERS.md](MAINTAINERS.md).
+
+While anyone can review a PR and is encouraged to do so, only maintainers are
+allowed to merge the PR. To maintain velocity, two approvals (either maintainers or reviewers) are
+required to merge a given PR. In case of a disagreement between maintainers, a
+vote should be called (on Github or Slack) and a simple majority is required in
+order for the PR to be merged.
+
+New maintainers must be nominated from contributors by an existing maintainer
+and must be elected by a [supermajority](#supermajority) of the current
+maintainers. Likewise, maintainers can be removed by a supermajority of the
+maintainers or can resign by notifying the maintainers.
+
+### Supermajority
+
+A supermajority is defined as two-thirds of members in the group.
+
+## Code of Conduct
+
+The code of conduct is overseen by the Bring Your Own Host project maintainers. Possible code
+of conduct violations should be emailed to the project maintainers.
+
+If the possible violation is against one of the project maintainers that member
+will be recused from voting on the issue.
+
+## Updating Governance
+
+All substantive changes in Governance require a supermajority vote of the
+maintainers.


### PR DESCRIPTION
**What this PR does / why we need it**:
The VMware OSS encourages all projects have a GOVERNANCE file detailing how we operate in the community.

Fixes #237 

**Additional Information**
Referred to https://github.com/antrea-io/antrea/blob/main/GOVERNANCE.md 
