### PR TITLE
Add host-agent integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
 
+    - name: turn off swap
+      run: sudo swapoff -a
+    
+    - name: Set netfilter conntrack max
+      run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
+
     - name: Set up Go
       uses: actions/setup-go@v2
       with:

--- a/Makefile
+++ b/Makefile
@@ -54,21 +54,6 @@ all: build
 
 HOST_AGENT_DIR ?= agent
 
-# Run tests
-test: generate fmt vet manifests test-coverage
-
-test-coverage:
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test .
-
-agent-test:
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out
-
-controller-test:
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs controllers/infrastructure -coverprofile cover.out
-
-webhook-test:
-	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo apis/infrastructure/v1beta1 -coverprofile cover.out
-
 ##@ General
 
 # The help target prints out all targets with their descriptions organized
@@ -124,6 +109,22 @@ prepare-byoh-docker-host-image:
 
 prepare-byoh-docker-host-image-dev:
 	docker build test/e2e -f docs/BYOHDockerFileDev -t ${BYOH_BASE_IMG_DEV}
+
+
+# Run tests
+test: generate fmt vet manifests test-coverage
+
+test-coverage:
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test .
+
+agent-test: docker-build prepare-byoh-docker-host-image 
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out
+
+controller-test:
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs controllers/infrastructure -coverprofile cover.out
+
+webhook-test:
+	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo apis/infrastructure/v1beta1 -coverprofile cover.out
 
 test-e2e: take-user-input docker-build prepare-byoh-docker-host-image $(GINKGO) cluster-templates-e2e ## Run the end-to-end tests
 	$(GINKGO) -v -trace -tags=e2e -focus="$(GINKGO_FOCUS)" $(_SKIP_ARGS) -nodes=$(GINKGO_NODES) --noColor=$(GINKGO_NOCOLOR) $(GINKGO_ARGS) test/e2e -- \

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ prepare-byoh-docker-host-image-dev:
 # Run tests
 test: generate fmt vet manifests test-coverage
 
-test-coverage: docker-build prepare-byoh-docker-host-image
+test-coverage: prepare-byoh-docker-host-image
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test .
 
-agent-test: docker-build prepare-byoh-docker-host-image
+agent-test: prepare-byoh-docker-host-image
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out
 
 controller-test:

--- a/Makefile
+++ b/Makefile
@@ -114,10 +114,10 @@ prepare-byoh-docker-host-image-dev:
 # Run tests
 test: generate fmt vet manifests test-coverage
 
-test-coverage:
+test-coverage: docker-build prepare-byoh-docker-host-image
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r --cover --coverprofile=cover.out --outputdir=. --skipPackage=test .
 
-agent-test: docker-build prepare-byoh-docker-host-image 
+agent-test: docker-build prepare-byoh-docker-host-image
 	source ./scripts/fetch_ext_bins.sh; fetch_tools; setup_envs; ginkgo --randomizeAllSpecs -r $(HOST_AGENT_DIR) -coverprofile cover.out
 
 controller-test:

--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -37,7 +37,7 @@ var (
 	tmpFilePrefix         = "kubeconfigFile-"
 	defaultByoMachineName = "my-byomachine"
 	agentLogFile          = "/tmp/agent-integration.log"
-	fakedKubeConfig       = "fake-kubeconfig-path"
+	fakeKubeConfig        = "fake-kubeconfig-path"
 	fakeDownloadPath      = "fake-download-path"
 	fakeBootstrapSecret   = "fake-bootstrap-secret"
 	testEnv               *envtest.Environment

--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -153,14 +153,14 @@ func setupTestInfra(ctx context.Context, hostname, kubeconfig string, namespace 
 	return &byohostRunner
 }
 
-func cleanup(context context.Context, byoHostContainer *container.ContainerCreateCreatedBody, namespace *corev1.Namespace, agentLogFile string) {
-	err := dockerClient.ContainerStop(context, byoHostContainer.ID, nil)
+func cleanup(ctx context.Context, byoHostContainer *container.ContainerCreateCreatedBody, namespace *corev1.Namespace, agentLogFile string) {
+	err := dockerClient.ContainerStop(ctx, byoHostContainer.ID, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	err = dockerClient.ContainerRemove(context, byoHostContainer.ID, dockertypes.ContainerRemoveOptions{})
+	err = dockerClient.ContainerRemove(ctx, byoHostContainer.ID, dockertypes.ContainerRemoveOptions{})
 	Expect(err).NotTo(HaveOccurred())
 
-	err = k8sClient.Delete(context, namespace)
+	err = k8sClient.Delete(ctx, namespace)
 	Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace")
 
 	_, err = os.Stat(agentLogFile)

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -144,7 +144,8 @@ var _ = Describe("Agent", func() {
 			ns = builder.Namespace("testns").Build()
 			Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(), "failed to create test namespace")
 			ctx = context.TODO()
-			hostName, err := os.Hostname()
+			var err error
+			hostName, err = os.Hostname()
 			Expect(err).NotTo(HaveOccurred())
 
 			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
@@ -305,13 +306,11 @@ var _ = Describe("Agent", func() {
 				updatedByoHost := &infrastructurev1beta1.ByoHost{}
 				Eventually(func() (condition corev1.ConditionStatus) {
 					err := k8sClient.Get(ctx, namespace, updatedByoHost)
-					if err != nil {
-						return corev1.ConditionFalse
-					}
-
-					kubeInstallStatus := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
-					if kubeInstallStatus != nil {
-						return kubeInstallStatus.Status
+					if err == nil {
+						kubeInstallStatus := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+						if kubeInstallStatus != nil {
+							return kubeInstallStatus.Status
+						}
 					}
 					return corev1.ConditionFalse
 				}, 60).Should(Equal(corev1.ConditionTrue))

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -7,26 +7,27 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/docker/api/types/container"
 	"github.com/jackpal/gateway"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gbytes"
 	"github.com/onsi/gomega/gexec"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version"
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/test/builder"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/test/e2e"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/cluster-api/util/patch"
 )
 
 var _ = Describe("Agent", func() {
@@ -34,13 +35,10 @@ var _ = Describe("Agent", func() {
 	Context("When the host is unable to register with the API server", func() {
 		var (
 			ns               *corev1.Namespace
-			ctx context.Context
+			ctx              context.Context
 			err              error
 			hostName         string
-			fakedKubeConfig  = "fake-kubeconfig-path"
-			fakeDownloadPath = "fake-download-path"
-			agentLogFile = "/tmp/agent-integration.log"
-			runner    *e2e.ByoHostRunner
+			runner           *e2e.ByoHostRunner
 			byoHostContainer *container.ContainerCreateCreatedBody
 		)
 
@@ -51,15 +49,15 @@ var _ = Describe("Agent", func() {
 
 			hostName, err = os.Hostname()
 			Expect(err).NotTo(HaveOccurred())
-			runner = setupTestInfra(ctx, getKubeConfig().Name(), ns)
-			
+			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
+
 			byoHostContainer, err = runner.SetupByoDockerHost()
 			Expect(err).NotTo(HaveOccurred())
 
 		})
 
 		AfterEach(func() {
-			CleanupBuildArtifacts(runner.Context, byoHostContainer, ns, agentLogFile)
+			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
 		})
 
 		It("should not error out if the host already exists", func() {
@@ -92,22 +90,15 @@ var _ = Describe("Agent", func() {
 				}
 			}()
 			Consistently(func() (done bool) {
-				_, err := os.Stat(agentLogFile);
-				if  err == nil {
+				_, err := os.Stat(agentLogFile)
+				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					if err == nil {
-						e2e.Showf(string(data))
-					}
-					if err == nil && strings.Contains(string(data), "\"msg\"=\"error\"")  {
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"error\"") {
 						return true
 					}
 				}
 				return false
-			}).Should(BeFalse())
-			// command := exec.Command(pathToHostAgentBinary, "--kubeconfig", kubeconfigFile.Name(), "--namespace", ns.Name, "--downloadpath", fakeDownloadPath)
-			// session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
-			// Expect(err).NotTo(HaveOccurred())
-			// Consistently(session).ShouldNot(gexec.Exit(0))
+			}, 10).Should(BeFalse())
 		})
 
 		It("should return an error when invalid kubeconfig is passed in", func() {
@@ -116,7 +107,7 @@ var _ = Describe("Agent", func() {
 			output, _, err := runner.ExecByoDockerHost(byoHostContainer)
 			Expect(err).NotTo(HaveOccurred())
 			defer output.Close()
-			
+
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
 				deferredErr := f.Close()
@@ -125,15 +116,15 @@ var _ = Describe("Agent", func() {
 				}
 			}()
 			Eventually(func() (done bool) {
-				_, err := os.Stat(agentLogFile);
-				if  err == nil {
+				_, err := os.Stat(agentLogFile)
+				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					if err == nil && strings.Contains(string(data), "\"msg\"=\"error getting kubeconfig\"")  {
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"error getting kubeconfig\"") {
 						return true
 					}
 				}
 				return false
-			}).Should(BeTrue())
+			}, 10).Should(BeTrue())
 		})
 	})
 
@@ -141,35 +132,35 @@ var _ = Describe("Agent", func() {
 
 		var (
 			ns               *corev1.Namespace
-			session          *gexec.Session
+			ctx              context.Context
 			err              error
-			workDir          string
 			hostName         string
 			fakeDownloadPath = "fake-download-path"
+			runner           *e2e.ByoHostRunner
+			byoHostContainer *container.ContainerCreateCreatedBody
+			output           dockertypes.HijackedResponse
 		)
 
 		BeforeEach(func() {
 			ns = builder.Namespace("testns").Build()
 			Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(), "failed to create test namespace")
-
+			ctx = context.TODO()
 			hostName, err = os.Hostname()
 			Expect(err).NotTo(HaveOccurred())
 
-			command := exec.Command(pathToHostAgentBinary, "--kubeconfig", kubeconfigFile.Name(), "--namespace", ns.Name, "--label", "site=apac", "--downloadpath", fakeDownloadPath)
+			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
+			runner.CommandArgs["--label"] = "site=apac"
+			runner.CommandArgs["--downloadpath"] = fakeDownloadPath
 
-			session, err = gexec.Start(command, GinkgoWriter, GinkgoWriter)
+			byoHostContainer, err = runner.SetupByoDockerHost()
 			Expect(err).NotTo(HaveOccurred())
 
-			workDir, err = ioutil.TempDir("", "host-agent-ut")
+			output, _, err = runner.ExecByoDockerHost(byoHostContainer)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
-			err = k8sClient.Delete(context.TODO(), ns)
-			Expect(err).NotTo(HaveOccurred())
-			err = os.RemoveAll(workDir)
-			Expect(err).NotTo(HaveOccurred())
-			session.Terminate().Wait()
+			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
 		})
 
 		It("should register the BYOHost with the management cluster", func() {
@@ -181,7 +172,7 @@ var _ = Describe("Agent", func() {
 					return nil
 				}
 				return createdByoHost
-			}).ShouldNot(BeNil())
+			}, 30).ShouldNot(BeNil())
 		})
 
 		It("should register the BYOHost with the passed labels", func() {
@@ -193,7 +184,7 @@ var _ = Describe("Agent", func() {
 					return nil
 				}
 				return createdByoHost.ObjectMeta.Labels
-			}).Should(Equal(map[string]string{"site": "apac"}))
+			}, 30).Should(Equal(map[string]string{"site": "apac"}))
 		})
 
 		It("should fetch networkstatus when register the BYOHost with the management cluster", func() {
@@ -234,7 +225,7 @@ var _ = Describe("Agent", func() {
 					}
 				}
 				return false
-			}).Should(BeTrue())
+			}, 30).Should(BeTrue())
 
 		})
 
@@ -242,7 +233,87 @@ var _ = Describe("Agent", func() {
 			byoHost := builder.ByoHost(ns.Name, "random-second-host").Build()
 			Expect(k8sClient.Create(context.TODO(), byoHost)).NotTo(HaveOccurred(), "failed to create byohost")
 
-			Consistently(session.Err, "10s").ShouldNot(gbytes.Say(byoHost.Name))
+			defer output.Close()
+
+			f := e2e.WriteDockerLog(output, agentLogFile)
+			defer func() {
+				deferredErr := f.Close()
+				if deferredErr != nil {
+					e2e.Showf("error closing file %s: %v", agentLogFile, deferredErr)
+				}
+			}()
+			Consistently(func() (done bool) {
+				_, err := os.Stat(agentLogFile)
+				if err == nil {
+					data, err := os.ReadFile(agentLogFile)
+					if err == nil && strings.Contains(string(data), byoHost.Name) {
+						return true
+					}
+				}
+				return false
+			}, 10, 1).ShouldNot(BeTrue())
+		})
+		Context("when machineref & bootstrap is assigned", func() {
+			var (
+				byoMachine *infrastructurev1beta1.ByoMachine
+				namespace  types.NamespacedName
+			)
+			BeforeEach(func() {
+				byoMachine = builder.ByoMachine(ns.Name, defaultByoMachineName).Build()
+				Expect(k8sClient.Create(ctx, byoMachine)).Should(Succeed())
+				byoHost := &infrastructurev1beta1.ByoHost{}
+				namespace = types.NamespacedName{Name: hostName, Namespace: ns.Name}
+				Eventually(func() (err error) {
+					err = k8sClient.Get(ctx, namespace, byoHost)
+					return err
+				}).Should(BeNil())
+
+				patchHelper, _ := patch.NewHelper(byoHost, k8sClient)
+				byoHost.Status.MachineRef = &corev1.ObjectReference{
+					APIVersion: byoMachine.APIVersion,
+					Kind:       byoMachine.Kind,
+					Namespace:  byoMachine.Namespace,
+					Name:       byoMachine.Name,
+					UID:        byoMachine.UID,
+				}
+				byoHost.Annotations = map[string]string{}
+				byoHost.Annotations[infrastructurev1beta1.K8sVersionAnnotation] = K8sVersion
+				byoHost.Annotations[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation] = bundleLookupBaseRegistry
+				byoHost.Annotations[infrastructurev1beta1.BundleLookupTagAnnotation] = BundleLookupTag
+
+				fakeBootstrapSecret := builder.Secret(ns.Name, fakeBootstrapSecret).Build()
+				k8sClient.Create(ctx, fakeBootstrapSecret)
+				byoHost.Spec.BootstrapSecret = &corev1.ObjectReference{
+					Kind:      "Secret",
+					Namespace: byoMachine.Namespace,
+					Name:      fakeBootstrapSecret.Name,
+				}
+
+				Expect(patchHelper.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).NotTo(HaveOccurred())
+			})
+
+			It("should install k8s components", func() {
+
+				defer output.Close()
+				f := e2e.WriteDockerLog(output, agentLogFile)
+				defer func() {
+					deferredErr := f.Close()
+					if deferredErr != nil {
+						e2e.Showf("error closing file %s: %v", agentLogFile, deferredErr)
+					}
+				}()
+				updatedByoHost := &infrastructurev1beta1.ByoHost{}
+				Eventually(func() (condition corev1.ConditionStatus) {
+					err = k8sClient.Get(ctx, namespace, updatedByoHost)
+					Expect(err).ToNot(HaveOccurred())
+
+					kubeInstallStatus := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+					if kubeInstallStatus != nil {
+						return kubeInstallStatus.Status
+					}
+					return corev1.ConditionFalse
+				}, 60).Should(Equal(corev1.ConditionTrue))
+			})
 		})
 	})
 
@@ -282,6 +353,63 @@ var _ = Describe("Agent", func() {
 			Expect(err).NotTo(HaveOccurred())
 			output := string(out)
 			Expect(output).Should(Equal(expected))
+		})
+	})
+
+	Context("When the host agent is executed with --skip-installation flag", func() {
+		var (
+			ns               *corev1.Namespace
+			ctx              context.Context
+			err              error
+			hostName         string
+			agentLogFile     = "/tmp/agent-integration.log"
+			fakeDownloadPath = "fake-download-path"
+			runner           *e2e.ByoHostRunner
+			byoHostContainer *container.ContainerCreateCreatedBody
+		)
+
+		BeforeEach(func() {
+			ns = builder.Namespace("testns").Build()
+			ctx = context.TODO()
+			Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(), "failed to create test namespace")
+
+			hostName, err = os.Hostname()
+			Expect(err).NotTo(HaveOccurred())
+			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
+
+			byoHostContainer, err = runner.SetupByoDockerHost()
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
+		})
+
+		It("should skip installation of k8s components", func() {
+			runner.CommandArgs["--downloadpath"] = fakeDownloadPath
+			runner.CommandArgs["--skip-installation"] = ""
+			output, _, err := runner.ExecByoDockerHost(byoHostContainer)
+			Expect(err).NotTo(HaveOccurred())
+
+			defer output.Close()
+			f := e2e.WriteDockerLog(output, agentLogFile)
+			defer func() {
+				deferredErr := f.Close()
+				if deferredErr != nil {
+					e2e.Showf("error closing file %s: %v", agentLogFile, deferredErr)
+				}
+			}()
+			Eventually(func() (done bool) {
+				_, err := os.Stat(agentLogFile)
+				if err == nil {
+					data, err := os.ReadFile(agentLogFile)
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"skip-installation flag set, skipping installer initialisation\"") {
+						return true
+					}
+				}
+				return false
+			}, 30).Should(BeTrue())
 		})
 	})
 })

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Agent", func() {
 						}
 					}
 					return corev1.ConditionFalse
-				}, 60).Should(Equal(corev1.ConditionTrue))
+				}, 600).Should(Equal(corev1.ConditionTrue))
 			})
 		})
 	})

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Agent", func() {
 						}
 					}
 					return corev1.ConditionFalse
-				}, 600).Should(Equal(corev1.ConditionTrue))
+				}, 60).Should(Equal(corev1.ConditionTrue))
 			})
 		})
 	})

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -98,12 +98,12 @@ var _ = Describe("Agent", func() {
 					}
 				}
 				return false
-			}, 10).Should(BeFalse())
+			}).Should(BeFalse())
 		})
 
 		It("should return an error when invalid kubeconfig is passed in", func() {
 
-			runner.CommandArgs["--kubeconfig"] = fakedKubeConfig
+			runner.CommandArgs["--kubeconfig"] = fakeKubeConfig
 			output, _, err := runner.ExecByoDockerHost(byoHostContainer)
 			Expect(err).NotTo(HaveOccurred())
 			defer output.Close()
@@ -124,7 +124,7 @@ var _ = Describe("Agent", func() {
 					}
 				}
 				return false
-			}, 10).Should(BeTrue())
+			}).Should(BeTrue())
 		})
 	})
 
@@ -172,7 +172,7 @@ var _ = Describe("Agent", func() {
 					return nil
 				}
 				return createdByoHost
-			}, 30).ShouldNot(BeNil())
+			}).ShouldNot(BeNil())
 		})
 
 		It("should register the BYOHost with the passed labels", func() {
@@ -184,7 +184,7 @@ var _ = Describe("Agent", func() {
 					return nil
 				}
 				return createdByoHost.ObjectMeta.Labels
-			}, 30).Should(Equal(map[string]string{"site": "apac"}))
+			}).Should(Equal(map[string]string{"site": "apac"}))
 		})
 
 		It("should fetch networkstatus when register the BYOHost with the management cluster", func() {
@@ -225,7 +225,7 @@ var _ = Describe("Agent", func() {
 					}
 				}
 				return false
-			}, 30).Should(BeTrue())
+			}).Should(BeTrue())
 
 		})
 
@@ -253,7 +253,7 @@ var _ = Describe("Agent", func() {
 				return false
 			}, 10, 1).ShouldNot(BeTrue())
 		})
-		Context("when machineref & bootstrap is assigned", func() {
+		Context("when machineref & bootstrap secret is assigned", func() {
 			var (
 				byoMachine *infrastructurev1beta1.ByoMachine
 				namespace  types.NamespacedName

--- a/agent/main.go
+++ b/agent/main.go
@@ -85,8 +85,8 @@ func setupflags() {
 	flag.BoolVar(&printVersion, "version", false, "Print the version of the agent")
 
 	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
-	hiddenFlags := [] string{"log-flush-frequency", "alsologtostderr", "log-backtrace-at", "log-dir", "logtostderr", "stderrthreshold", "vmodule", "azure-container-registry-config",
-							 "log_backtrace_at", "log_dir", "log_file", "log_file_max_size", "add_dir_header", "skip_headers", "skip_log_headers"}
+	hiddenFlags := []string{"log-flush-frequency", "alsologtostderr", "log-backtrace-at", "log-dir", "logtostderr", "stderrthreshold", "vmodule", "azure-container-registry-config",
+		"log_backtrace_at", "log_dir", "log_file", "log_file_max_size", "add_dir_header", "skip_headers", "skip_log_headers"}
 	for _, hiddenFlag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(hiddenFlag)
 	}

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -74,7 +74,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		setDockerClient(client)
 
 		runner := ByoHostRunner{
-			Context:                   ctx,
+			Context:               ctx,
 			clusterConName:        clusterConName,
 			Namespace:             namespace.Name,
 			PathToHostAgentBinary: pathToHostAgentBinary,

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -47,6 +47,7 @@ func WriteDockerLog(output types.HijackedResponse, outputFile string) *os.File {
 			select {
 			case line := <-s:
 				_, err2 := f.WriteString(line + "\n")
+				Showf(line + "\n")
 				if err2 != nil {
 					Showf("Write String to file failed, err2=%v", err2)
 				}

--- a/test/e2e/e2e_debug_helper.go
+++ b/test/e2e/e2e_debug_helper.go
@@ -47,7 +47,6 @@ func WriteDockerLog(output types.HijackedResponse, outputFile string) *os.File {
 			select {
 			case line := <-s:
 				_, err2 := f.WriteString(line + "\n")
-				Showf(line + "\n")
 				if err2 != nil {
 					Showf("Write String to file failed, err2=%v", err2)
 				}

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -72,13 +72,13 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
 
 			runner := ByoHostRunner{
-				Context:                   ctx,
+				Context:               ctx,
 				clusterConName:        clusterConName,
 				ByoHostName:           byoHostName,
 				Namespace:             namespace.Name,
 				PathToHostAgentBinary: pathToHostAgentBinary,
 				DockerClient:          dockerClient,
-				NetworkInterface: "kind",
+				NetworkInterface:      "kind",
 				bootstrapClusterProxy: bootstrapClusterProxy,
 				CommandArgs: map[string]string{
 					"--kubeconfig": "/mgmt.conf",


### PR DESCRIPTION
**What this PR does / why we need it**:
Add integration tests for `installK8sComponents`. Also updates the existing `host-agent` tests to run within docker-based environments.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #393 