### PR TITLE
Add support for host-agent integration tests

### DIFF
--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -5,7 +5,6 @@
 package main
 
 import (
-	"context"
 	"go/build"
 	"io/ioutil"
 	"os"
@@ -20,7 +19,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -112,30 +110,4 @@ func writeKubeConfig() {
 
 	_, err = getKubeConfig().Write(kubeConfigData)
 	Expect(err).NotTo(HaveOccurred())
-}
-
-func dumpSpecResourcesAndCleanup(ctx context.Context, artifactFolder string, namespace *corev1.Namespace, skipCleanup bool) {
-	// e2e.Byf("Dumping logs from the %q workload cluster", cluster.Name)
-
-	// Dump all the logs from the workload cluster before deleting them.
-	// clusterProxy.CollectWorkloadClusterLogs(ctx, cluster.Namespace, cluster.Name, filepath.Join(artifactFolder, "clusters", cluster.Name, "machines"))
-
-	// e2e.Byf("Dumping all the Cluster API resources in the %q namespace", namespace.Name)
-
-	// Dump all Cluster API related resources to artifacts before deleting them.
-	// framework.DumpAllResources(ctx, framework.DumpAllResourcesInput{
-	// 	Lister:    clusterProxy.GetClient(),
-	// 	Namespace: namespace.Name,
-	// 	LogPath:   filepath.Join(artifactFolder, "clusters", clusterProxy.GetName(), "resources"),
-	// })
-
-	if !skipCleanup {
-		e2e.Byf("Deleting cluster %s", namespace.Name)
-		// framework.DeleteNamespace(ctx, framework.DeleteNamespaceInput{
-		// 	Deleter: clusterProxy.GetClient(),
-		// 	Name:    namespace.Name,
-		// })
-		err := k8sClient.Delete(context.TODO(), namespace)
-		Expect(err).NotTo(HaveOccurred(), "failed to delete test namespace")
-	}
 }

--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -52,7 +52,6 @@ var _ = BeforeSuite(func() {
 		CRDDirectoryPaths: []string{
 			filepath.Join("..", "config", "crd", "bases"),
 			filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "cluster-api@v1.0.4", "config", "crd", "bases"),
-			filepath.Join(build.Default.GOPATH, "pkg", "mod", "sigs.k8s.io", "cluster-api@v1.0.4", "bootstrap", "kubeadm", "config", "crd", "bases"),
 		},
 
 		ErrorIfCRDPathMissing: true,

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -67,8 +67,22 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		Expect(err).NotTo(HaveOccurred())
 		setDockerClient(client)
 
+		config := byoHostConfig{
+			ctx:                   ctx,
+			clusterConName:        clusterConName,
+			namespace:             namespace.Name,
+			dockerClient:          dockerClient,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			commandArgs: map[string]string{
+				"--kubeconfig": "/mgmt.conf",
+				"--namespace":  namespace.Name,
+				"--v":          "1",
+			},
+		}
+
 		var output types.HijackedResponse
-		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, getDockerClient(), bootstrapClusterProxy)
+		config.byoHostName = byoHostName1
+		output, byohostContainerID, err := setupByoDockerHost(config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -80,7 +94,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			}
 		}()
 
-		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, getDockerClient(), bootstrapClusterProxy)
+		config.byoHostName = byoHostName2
+		output, byohostContainerID, err = setupByoDockerHost(config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -31,14 +32,16 @@ var (
 var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 	var (
-		ctx                 context.Context
-		specName            = "byohost-reuse"
-		namespace           *corev1.Namespace
-		cancelWatches       context.CancelFunc
-		clusterResources    *clusterctl.ApplyClusterTemplateAndWaitResult
-		byohostContainerIDs []string
-		agentLogFile1       = "/tmp/host-agent1.log"
-		agentLogFile2       = "/tmp/host-agent-reuse.log"
+		ctx                   context.Context
+		specName              = "byohost-reuse"
+		namespace             *corev1.Namespace
+		cancelWatches         context.CancelFunc
+		clusterResources      *clusterctl.ApplyClusterTemplateAndWaitResult
+		byohostContainerIDs   []string
+		agentLogFile1         = "/tmp/host-agent1.log"
+		agentLogFile2         = "/tmp/host-agent-reuse.log"
+		pathToHostAgentBinary string
+		err                   error
 	)
 
 	BeforeEach(func() {
@@ -52,6 +55,9 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
+		Expect(err).NotTo(HaveOccurred())
 
 		// set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
@@ -71,6 +77,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			ctx:                   ctx,
 			clusterConName:        clusterConName,
 			namespace:             namespace.Name,
+			pathToHostAgentBinary: pathToHostAgentBinary,
 			dockerClient:          dockerClient,
 			bootstrapClusterProxy: bootstrapClusterProxy,
 			commandArgs: map[string]string{

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -82,7 +82,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		var output types.HijackedResponse
 		config.byoHostName = byoHostName1
-		output, byohostContainerID, err := setupByoDockerHost(config, true)
+		output, byohostContainerID, err := setupByoDockerHost(&config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -95,7 +95,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}()
 
 		config.byoHostName = byoHostName2
-		output, byohostContainerID, err = setupByoDockerHost(config, true)
+		output, byohostContainerID, err = setupByoDockerHost(&config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -73,14 +73,14 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		Expect(err).NotTo(HaveOccurred())
 		setDockerClient(client)
 
-		config := byoHostConfig{
-			ctx:                   ctx,
+		runner := ByoHostRunner{
+			Context:                   ctx,
 			clusterConName:        clusterConName,
-			namespace:             namespace.Name,
-			pathToHostAgentBinary: pathToHostAgentBinary,
+			Namespace:             namespace.Name,
+			PathToHostAgentBinary: pathToHostAgentBinary,
 			dockerClient:          dockerClient,
 			bootstrapClusterProxy: bootstrapClusterProxy,
-			commandArgs: map[string]string{
+			CommandArgs: map[string]string{
 				"--kubeconfig": "/mgmt.conf",
 				"--namespace":  namespace.Name,
 				"--v":          "1",
@@ -88,8 +88,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}
 
 		var output types.HijackedResponse
-		config.byoHostName = byoHostName1
-		output, byohostContainerID, err := setupByoDockerHost(&config, true)
+		runner.ByoHostName = byoHostName1
+		output, byohostContainerID, err := runner.SetupByoDockerHost(true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -101,8 +101,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			}
 		}()
 
-		config.byoHostName = byoHostName2
-		output, byohostContainerID, err = setupByoDockerHost(&config, true)
+		runner.ByoHostName = byoHostName2
+		output, byohostContainerID, err = runner.SetupByoDockerHost(true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -78,7 +78,8 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			clusterConName:        clusterConName,
 			Namespace:             namespace.Name,
 			PathToHostAgentBinary: pathToHostAgentBinary,
-			dockerClient:          dockerClient,
+			DockerClient:          dockerClient,
+			NetworkInterface:      "kind",
 			bootstrapClusterProxy: bootstrapClusterProxy,
 			CommandArgs: map[string]string{
 				"--kubeconfig": "/mgmt.conf",
@@ -89,7 +90,9 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		var output types.HijackedResponse
 		runner.ByoHostName = byoHostName1
-		output, byohostContainerID, err := runner.SetupByoDockerHost(true)
+		byohost, rconfig, err := runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -102,7 +105,9 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}()
 
 		runner.ByoHostName = byoHostName2
-		output, byohostContainerID, err = runner.SetupByoDockerHost(true)
+		byohost, rconfig, err = runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost, rconfig)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -90,9 +90,9 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 		var output types.HijackedResponse
 		runner.ByoHostName = byoHostName1
-		byohost, rconfig, err := runner.SetupByoDockerHost()
+		byohost, err := runner.SetupByoDockerHost()
 		Expect(err).NotTo(HaveOccurred())
-		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
+		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -105,9 +105,9 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		}()
 
 		runner.ByoHostName = byoHostName2
-		byohost, rconfig, err = runner.SetupByoDockerHost()
+		byohost, err = runner.SetupByoDockerHost()
 		Expect(err).NotTo(HaveOccurred())
-		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost, rconfig)
+		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -48,7 +48,7 @@ type ByoHostRunner struct {
 	bootstrapClusterProxy framework.ClusterProxy
 	CommandArgs           map[string]string
 	Port                  string
-	KubeconfigFile        *os.File
+	KubeconfigFile        string
 }
 
 func resolveLocalPath(localPath string) (absPath string, err error) {
@@ -180,7 +180,7 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(containers)).To(Equal(1))
 
-		kubeconfig, err = os.ReadFile(r.KubeconfigFile.Name())
+		kubeconfig, err = os.ReadFile(r.KubeconfigFile)
 		Expect(err).NotTo(HaveOccurred())
 
 		re := regexp.MustCompile("server:.*")

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -171,7 +171,7 @@ func createDockerContainer(ctx context.Context, networkInterface, byoHostName st
 		nil, byoHostName)
 }
 
-func copyKubeconfig(dockerConfig byoHostConfig, config cpConfig, listopt types.ContainerListOptions, e2eTest bool) error {
+func copyKubeconfig(dockerConfig *byoHostConfig, config cpConfig, listopt types.ContainerListOptions, e2eTest bool) error {
 	var kubeconfig []byte
 	if e2eTest {
 		listopt.Filters.Add("name", dockerConfig.clusterConName+"-control-plane")
@@ -209,7 +209,7 @@ func copyKubeconfig(dockerConfig byoHostConfig, config cpConfig, listopt types.C
 	return err
 }
 
-func setupByoDockerHost(dockerConfig byoHostConfig, e2eTest bool) (types.HijackedResponse, string, error) {
+func setupByoDockerHost(dockerConfig *byoHostConfig, e2eTest bool) (types.HijackedResponse, string, error) {
 	var byohost container.ContainerCreateCreatedBody
 	var err error
 	if e2eTest {

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/system"
 	. "github.com/onsi/gomega" // nolint: stylecheck
-	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api/test/framework"
 )
@@ -42,6 +41,7 @@ type byoHostConfig struct {
 	ctx                   context.Context
 	clusterConName        string
 	byoHostName           string
+	pathToHostAgentBinary string
 	namespace             string
 	dockerClient          *client.Client
 	bootstrapClusterProxy framework.ClusterProxy
@@ -220,11 +220,8 @@ func setupByoDockerHost(dockerConfig *byoHostConfig, e2eTest bool) (types.Hijack
 	Expect(err).NotTo(HaveOccurred())
 	Expect(dockerConfig.dockerClient.ContainerStart(dockerConfig.ctx, byohost.ID, types.ContainerStartOptions{})).NotTo(HaveOccurred())
 
-	pathToHostAgentBinary, err := gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
-	Expect(err).NotTo(HaveOccurred())
-
 	config := cpConfig{
-		sourcePath: pathToHostAgentBinary,
+		sourcePath: dockerConfig.pathToHostAgentBinary,
 		destPath:   "/agent",
 		container:  byohost.ID,
 	}

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -155,7 +155,7 @@ func copyToContainer(ctx context.Context, cli *client.Client, copyConfig cpConfi
 	return cli.CopyToContainer(ctx, copyConfig.container, resolvedDstPath, content, options)
 }
 
-func (r ByoHostRunner) createDockerContainer() (container.ContainerCreateCreatedBody, error) {
+func (r *ByoHostRunner) createDockerContainer() (container.ContainerCreateCreatedBody, error) {
 	tmpfs := map[string]string{"/run": "", "/tmp": ""}
 
 	return r.DockerClient.ContainerCreate(r.Context,
@@ -175,7 +175,6 @@ func (r ByoHostRunner) createDockerContainer() (container.ContainerCreateCreated
 func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerListOptions) error {
 	var kubeconfig []byte
 	if r.NetworkInterface == "host" {
-
 		listopt.Filters.Add("name", r.ByoHostName)
 		containers, err := r.DockerClient.ContainerList(r.Context, listopt)
 		Expect(err).NotTo(HaveOccurred())
@@ -187,7 +186,6 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 		re := regexp.MustCompile("server:.*")
 		kubeconfig = re.ReplaceAll(kubeconfig, []byte("server: https://127.0.0.1:"+r.Port))
 	} else {
-
 		listopt.Filters.Add("name", r.clusterConName+"-control-plane")
 		containers, err := r.DockerClient.ContainerList(r.Context, listopt)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -270,8 +270,7 @@ func SetupByoDockerHostWithConfig(ctx context.Context, byoHostName, port, namesp
 	var cmdArgs []string 
 	cmdArgs = append(cmdArgs, "./agent")
 	for flag, arg := range flags {
-		cmdArgs = append(cmdArgs, flag)
-		cmdArgs = append(cmdArgs, arg)
+		cmdArgs = append(cmdArgs, flag, arg)
 	}
 	rconfig := types.ExecConfig{
 		AttachStdout: true,

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -85,7 +85,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 
 		var output types.HijackedResponse
 		config.byoHostName = byoHostName1
-		output, byohostContainerID, err := setupByoDockerHost(config, true)
+		output, byohostContainerID, err := setupByoDockerHost(&config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -98,7 +98,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		}()
 
 		config.byoHostName = byoHostName2
-		output, byohostContainerID, err = setupByoDockerHost(config, true)
+		output, byohostContainerID, err = setupByoDockerHost(&config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -75,14 +75,14 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		dockerClient, err = client.NewClientWithOpts(client.FromEnv)
 		Expect(err).NotTo(HaveOccurred())
 
-		config := byoHostConfig{
-			ctx:                   ctx,
+		runner := ByoHostRunner{
+			Context:                   ctx,
 			clusterConName:        clusterConName,
-			namespace:             namespace.Name,
-			pathToHostAgentBinary: pathToHostAgentBinary,
+			Namespace:             namespace.Name,
+			PathToHostAgentBinary: pathToHostAgentBinary,
 			dockerClient:          dockerClient,
 			bootstrapClusterProxy: bootstrapClusterProxy,
-			commandArgs: map[string]string{
+			CommandArgs: map[string]string{
 				"--kubeconfig": "/mgmt.conf",
 				"--namespace":  namespace.Name,
 				"--v":          "1",
@@ -90,8 +90,8 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		}
 
 		var output types.HijackedResponse
-		config.byoHostName = byoHostName1
-		output, byohostContainerID, err := setupByoDockerHost(&config, true)
+		runner.ByoHostName = byoHostName1
+		output, byohostContainerID, err := runner.SetupByoDockerHost(true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -103,8 +103,8 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		config.byoHostName = byoHostName2
-		output, byohostContainerID, err = setupByoDockerHost(&config, true)
+		runner.ByoHostName = byoHostName2
+		output, byohostContainerID, err = runner.SetupByoDockerHost(true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -76,11 +76,12 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		runner := ByoHostRunner{
-			Context:                   ctx,
+			Context:               ctx,
 			clusterConName:        clusterConName,
 			Namespace:             namespace.Name,
 			PathToHostAgentBinary: pathToHostAgentBinary,
-			dockerClient:          dockerClient,
+			DockerClient:          dockerClient,
+			NetworkInterface:      "kind",
 			bootstrapClusterProxy: bootstrapClusterProxy,
 			CommandArgs: map[string]string{
 				"--kubeconfig": "/mgmt.conf",
@@ -91,7 +92,9 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 
 		var output types.HijackedResponse
 		runner.ByoHostName = byoHostName1
-		output, byohostContainerID, err := runner.SetupByoDockerHost(true)
+		byohost, rconfig, err := runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -104,7 +107,9 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		}()
 
 		runner.ByoHostName = byoHostName2
-		output, byohostContainerID, err = runner.SetupByoDockerHost(true)
+		byohost, rconfig, err = runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost, rconfig)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -92,9 +92,9 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 
 		var output types.HijackedResponse
 		runner.ByoHostName = byoHostName1
-		byohost, rconfig, err := runner.SetupByoDockerHost()
+		byohost, err := runner.SetupByoDockerHost()
 		Expect(err).NotTo(HaveOccurred())
-		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
+		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -107,9 +107,9 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		}()
 
 		runner.ByoHostName = byoHostName2
-		byohost, rconfig, err = runner.SetupByoDockerHost()
+		byohost, err = runner.SetupByoDockerHost()
 		Expect(err).NotTo(HaveOccurred())
-		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost, rconfig)
+		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -70,8 +70,22 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		dockerClient, err = client.NewClientWithOpts(client.FromEnv)
 		Expect(err).NotTo(HaveOccurred())
 
+		config := byoHostConfig{
+			ctx:                   ctx,
+			clusterConName:        clusterConName,
+			namespace:             namespace.Name,
+			dockerClient:          dockerClient,
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			commandArgs: map[string]string{
+				"--kubeconfig": "/mgmt.conf",
+				"--namespace":  namespace.Name,
+				"--v":          "1",
+			},
+		}
+
 		var output types.HijackedResponse
-		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, dockerClient, bootstrapClusterProxy)
+		config.byoHostName = byoHostName1
+		output, byohostContainerID, err := setupByoDockerHost(config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -83,7 +97,8 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, dockerClient, bootstrapClusterProxy)
+		config.byoHostName = byoHostName2
+		output, byohostContainerID, err = setupByoDockerHost(config, true)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -77,7 +77,8 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 				ByoHostName:           byoHostName,
 				Namespace:             namespace.Name,
 				PathToHostAgentBinary: pathToHostAgentBinary,
-				dockerClient:          dockerClient,
+				DockerClient:          dockerClient,
+				NetworkInterface: "kind",
 				bootstrapClusterProxy: bootstrapClusterProxy,
 				CommandArgs: map[string]string{
 					"--kubeconfig": "/mgmt.conf",
@@ -85,7 +86,9 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 					"--v":          "1",
 				},
 			}
-			output, byohostContainerID, err := runner.SetupByoDockerHost(true)
+			byohost, rconfig, err := runner.SetupByoDockerHost()
+			Expect(err).NotTo(HaveOccurred())
+			output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -64,7 +64,21 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		for i := 0; i < byoHostCapacityPool; i++ {
 
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
-			output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName, namespace.Name, dockerClient, bootstrapClusterProxy)
+
+			config := byoHostConfig{
+				ctx:                   ctx,
+				clusterConName:        clusterConName,
+				byoHostName:           byoHostName,
+				namespace:             namespace.Name,
+				dockerClient:          dockerClient,
+				bootstrapClusterProxy: bootstrapClusterProxy,
+				commandArgs: map[string]string{
+					"--kubeconfig": "/mgmt.conf",
+					"--namespace":  namespace.Name,
+					"--v":          "1",
+				},
+			}
+			output, byohostContainerID, err := setupByoDockerHost(config, true)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -71,21 +71,21 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
 
-			config := byoHostConfig{
-				ctx:                   ctx,
+			runner := ByoHostRunner{
+				Context:                   ctx,
 				clusterConName:        clusterConName,
-				byoHostName:           byoHostName,
-				namespace:             namespace.Name,
-				pathToHostAgentBinary: pathToHostAgentBinary,
+				ByoHostName:           byoHostName,
+				Namespace:             namespace.Name,
+				PathToHostAgentBinary: pathToHostAgentBinary,
 				dockerClient:          dockerClient,
 				bootstrapClusterProxy: bootstrapClusterProxy,
-				commandArgs: map[string]string{
+				CommandArgs: map[string]string{
 					"--kubeconfig": "/mgmt.conf",
 					"--namespace":  namespace.Name,
 					"--v":          "1",
 				},
 			}
-			output, byohostContainerID, err := setupByoDockerHost(&config, true)
+			output, byohostContainerID, err := runner.SetupByoDockerHost(true)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/docker/docker/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -34,6 +35,8 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		byoHostName            string
 		allbyohostContainerIDs []string
 		allAgentLogFiles       []string
+		pathToHostAgentBinary  string
+		err                    error
 	)
 
 	BeforeEach(func() {
@@ -47,6 +50,9 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
+		Expect(err).NotTo(HaveOccurred())
 
 		// set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
@@ -70,6 +76,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 				clusterConName:        clusterConName,
 				byoHostName:           byoHostName,
 				namespace:             namespace.Name,
+				pathToHostAgentBinary: pathToHostAgentBinary,
 				dockerClient:          dockerClient,
 				bootstrapClusterProxy: bootstrapClusterProxy,
 				commandArgs: map[string]string{

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -86,9 +86,9 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 					"--v":          "1",
 				},
 			}
-			byohost, rconfig, err := runner.SetupByoDockerHost()
+			byohost, err := runner.SetupByoDockerHost()
 			Expect(err).NotTo(HaveOccurred())
-			output, byohostContainerID, err := runner.ExecByoDockerHost(byohost, rconfig)
+			output, byohostContainerID, err := runner.ExecByoDockerHost(byohost)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -78,7 +78,7 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 					"--v":          "1",
 				},
 			}
-			output, byohostContainerID, err := setupByoDockerHost(config, true)
+			output, byohostContainerID, err := setupByoDockerHost(&config, true)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Add support functions required for integration tests to be added for the `host-agent`. The integration tests will reuse functions from the E2E tests with some refactors, which are also included here.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partial #399 

**Additional information**
**Handle different network configurations for integration and E2E tests**
The E2E tests use `kind` for deploying the management cluster and then apply cluster-template in workload cluster. In the case of the integration tests, we wanted to use `envtest` instead, just like the controller integration tests.

The docker container creation helper methods were written with E2E tests in mind, so by default, they were creating containers in the `kind network`. However, in our case, the management cluster runs within the `host network`.

One workaround was to bind the `api-server` started by `envtest` to `0.0.0.0` so as to enable access from within Docker containers. However, the cert generated for the `api-server` by default is valid for localhost, and not for other addresses that we are binding to. One solution would have been to use `controller-runtime helpers` for generating certificates for the other addresses. However, we feel that would add unnecessary complexity to the tests.

Instead, we refactor the `createDockerContainer()` to dynamically attach the Docker container to the `host network` for envtest based clusters and to the `kind network` for E2E tests. This ensures that the management cluster and the hosts are in the same network.

**Handle redundant host-agent compilation**
The `SetupByoDockerHost()` was structured to always build the `host-agent` binary before setting up the docker containers. However, for tests involving multiple containers, this leads to the `host-agent` being compiled multiple times. To remove these redundant compilations, the agent build process has been moved to the BeforeEach() function of each test and a reference for the path to the compiled binary is passed to the `setupByoDockerHost()` function

**Separate Byoh docker create and exec**
The `SetupByoDockerHost()` has further been refactored to separate the docker creation and execution part, this would allow us to reuse the same docker container for multiple integration test cases