### PR TITLE
build byoh binary only once to save test time

### DIFF
--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -68,7 +68,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		setDockerClient(client)
 
 		var output types.HijackedResponse
-		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, getDockerClient(), bootstrapClusterProxy)
+		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, pathToHostAgentBinary, getDockerClient(), bootstrapClusterProxy)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -80,7 +80,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 			}
 		}()
 
-		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, getDockerClient(), bootstrapClusterProxy)
+		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, pathToHostAgentBinary, getDockerClient(), bootstrapClusterProxy)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/e2e_docker_helper.go
+++ b/test/e2e/e2e_docker_helper.go
@@ -20,7 +20,6 @@ import (
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/system"
 	. "github.com/onsi/gomega" // nolint: stylecheck
-	"github.com/onsi/gomega/gexec"
 	"github.com/pkg/errors"
 	"sigs.k8s.io/cluster-api/test/framework"
 )
@@ -159,17 +158,14 @@ func createDockerContainer(ctx context.Context, byoHostName string, dockerClient
 		nil, byoHostName)
 }
 
-func setupByoDockerHost(ctx context.Context, clusterConName, byoHostName, namespace string, dockerClient *client.Client, bootstrapClusterProxy framework.ClusterProxy) (types.HijackedResponse, string, error) {
+func setupByoDockerHost(ctx context.Context, clusterConName, byoHostName, namespace, byoBinaryPath string, dockerClient *client.Client, bootstrapClusterProxy framework.ClusterProxy) (types.HijackedResponse, string, error) {
 	byohost, err := createDockerContainer(ctx, byoHostName, dockerClient)
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(dockerClient.ContainerStart(ctx, byohost.ID, types.ContainerStartOptions{})).NotTo(HaveOccurred())
 
-	pathToHostAgentBinary, err := gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
-	Expect(err).NotTo(HaveOccurred())
-
 	config := cpConfig{
-		sourcePath: pathToHostAgentBinary,
+		sourcePath: byoBinaryPath,
 		destPath:   "/agent",
 		container:  byohost.ID,
 	}

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	infraproviderv1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +24,13 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
+)
+
+const (
+	KubernetesVersion = "KUBERNETES_VERSION"
+	CNIPath           = "CNI"
+	CNIResources      = "CNI_RESOURCES"
+	IPFamily          = "IP_FAMILY"
 )
 
 // Test suite flags
@@ -57,6 +65,8 @@ var (
 
 	// TODO: Remove this later
 	clusterConName string
+
+	pathToHostAgentBinary string
 )
 
 func init() {
@@ -94,6 +104,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By("Initializing the bootstrap cluster")
 	initBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
+
+	var err error
+	By("huchen: Start to build host agent binary")
+	pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
+	Expect(err).NotTo(HaveOccurred())
 
 	clusterConName = e2eConfig.ManagementClusterName
 	return []byte(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -20,13 +20,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-const (
-	KubernetesVersion = "KUBERNETES_VERSION"
-	CNIPath           = "CNI"
-	CNIResources      = "CNI_RESOURCES"
-	IPFamily          = "IP_FAMILY"
-)
-
 // creating a workload cluster
 // This test is meant to provide a first, fast signal to detect regression; it is recommended to use it as a PR blocker test.
 var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
@@ -71,7 +64,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		var output types.HijackedResponse
-		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, dockerClient, bootstrapClusterProxy)
+		output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName1, namespace.Name, pathToHostAgentBinary, dockerClient, bootstrapClusterProxy)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
@@ -83,7 +76,7 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 			}
 		}()
 
-		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, dockerClient, bootstrapClusterProxy)
+		output, byohostContainerID, err = setupByoDockerHost(ctx, clusterConName, byoHostName2, namespace.Name, pathToHostAgentBinary, dockerClient, bootstrapClusterProxy)
 		Expect(err).NotTo(HaveOccurred())
 		defer output.Close()
 		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -64,21 +64,21 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 		for i := 0; i < byoHostCapacityPool; i++ {
 
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
-			output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName, namespace.Name, dockerClient, bootstrapClusterProxy)
+			output, byohostContainerID, err := setupByoDockerHost(ctx, clusterConName, byoHostName, namespace.Name, pathToHostAgentBinary, dockerClient, bootstrapClusterProxy)
 			allbyohostContainerIDs = append(allbyohostContainerIDs, byohostContainerID)
 			Expect(err).NotTo(HaveOccurred())
 
 			// read the log of host agent container in backend, and write it
 			agentLogFile := fmt.Sprintf("/tmp/host-agent-%d.log", i)
-			func() {
-				f := WriteDockerLog(output, agentLogFile)
-				defer func() {
-					deferredErr := f.Close()
-					if deferredErr != nil {
-						Showf("error closing file %s:, %v", agentLogFile, deferredErr)
-					}
-				}()
+
+			f := WriteDockerLog(output, agentLogFile)
+			defer func() {
+				deferredErr := f.Close()
+				if deferredErr != nil {
+					Showf("error closing file %s:, %v", agentLogFile, deferredErr)
+				}
 			}()
+
 			allAgentLogFiles = append(allAgentLogFiles, agentLogFile)
 		}
 		// TODO: Write agent logs to files for better debugging


### PR DESCRIPTION
It takes time to building host agent separately for every container. If we move it to suit-test.go to run it only once for entire e2e. It can save some time. My test is as followed:

Before do this:

-     e2e_test: time elapse: 4m38.405165171s
-     md_scale_test: time elapse: 11m2.787283875s
-     byohost_reuse_test: time elapse: 7m14.318728577s

After do this:

-     e2e_test: time elapse: 5m27.469585284s
-     md_scale_test: time elapse: 7m26.022867913s
-     byohost_reuse_test: time elapse: 6m51.386107789s

It can save more time for md_scale_test obviously.

Plus, I found some issue our code, fix it in meantime.

- Writing byoh docker logs is not working, that's because we close file too early.
- Should not let md_scale_test and byohost_reuse_test depend on the code of e2e_test. 

Signed-off-by: chen hui <huchen@vmware.com>
