### PR TITLE
Adds default goal for Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
+.DEFAULT_GOAL := help
+
 all: build
 
 HOST_AGENT_DIR ?= agent


### PR DESCRIPTION
`make` doesn't provide default target options.
This PR adds a default goal for the same.

Signed-off-by: Jaybatra <jaybatra73@gmail.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #408 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->