### PR TITLE
build byoh binary only once to save test time

### DIFF
--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/docker/docker/client"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/onsi/gomega/gexec"
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -32,16 +31,14 @@ var (
 var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 
 	var (
-		ctx                   context.Context
-		specName              = "byohost-reuse"
-		namespace             *corev1.Namespace
-		cancelWatches         context.CancelFunc
-		clusterResources      *clusterctl.ApplyClusterTemplateAndWaitResult
-		byohostContainerIDs   []string
-		agentLogFile1         = "/tmp/host-agent1.log"
-		agentLogFile2         = "/tmp/host-agent-reuse.log"
-		pathToHostAgentBinary string
-		err                   error
+		ctx                 context.Context
+		specName            = "byohost-reuse"
+		namespace           *corev1.Namespace
+		cancelWatches       context.CancelFunc
+		clusterResources    *clusterctl.ApplyClusterTemplateAndWaitResult
+		byohostContainerIDs []string
+		agentLogFile1       = "/tmp/host-agent1.log"
+		agentLogFile2       = "/tmp/host-agent-reuse.log"
 	)
 
 	BeforeEach(func() {
@@ -55,9 +52,6 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
-
-		pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
-		Expect(err).NotTo(HaveOccurred())
 
 		// set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
@@ -74,7 +68,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		setDockerClient(client)
 
 		runner := ByoHostRunner{
-			Context:                   ctx,
+			Context:               ctx,
 			clusterConName:        clusterConName,
 			Namespace:             namespace.Name,
 			PathToHostAgentBinary: pathToHostAgentBinary,

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -106,7 +106,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	initBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
 
 	var err error
-	By("huchen: Start to build host agent binary")
+	By("building host agent binary")
 	pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
 	infraproviderv1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,6 +24,13 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework/bootstrap"
 	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
 	"sigs.k8s.io/cluster-api/util"
+)
+
+const (
+	KubernetesVersion = "KUBERNETES_VERSION"
+	CNIPath           = "CNI"
+	CNIResources      = "CNI_RESOURCES"
+	IPFamily          = "IP_FAMILY"
 )
 
 // Test suite flags
@@ -57,6 +65,8 @@ var (
 
 	// TODO: Remove this later
 	clusterConName string
+
+	pathToHostAgentBinary string
 )
 
 func init() {
@@ -94,6 +104,11 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 
 	By("Initializing the bootstrap cluster")
 	initBootstrapCluster(bootstrapClusterProxy, e2eConfig, clusterctlConfigPath, artifactFolder)
+
+	var err error
+	By("huchen: Start to build host agent binary")
+	pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
+	Expect(err).NotTo(HaveOccurred())
 
 	clusterConName = e2eConfig.ManagementClusterName
 	return []byte(

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -7,7 +7,6 @@ package e2e
 import (
 	"context"
 	"fmt"
-	"github.com/onsi/gomega/gexec"
 	"os"
 	"path/filepath"
 
@@ -21,30 +20,22 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-const (
-	KubernetesVersion = "KUBERNETES_VERSION"
-	CNIPath           = "CNI"
-	CNIResources      = "CNI_RESOURCES"
-	IPFamily          = "IP_FAMILY"
-)
-
 // creating a workload cluster
 // This test is meant to provide a first, fast signal to detect regression; it is recommended to use it as a PR blocker test.
 var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 
 	var (
-		ctx                   context.Context
-		specName              = "quick-start"
-		namespace             *corev1.Namespace
-		clusterName           string
-		cancelWatches         context.CancelFunc
-		clusterResources      *clusterctl.ApplyClusterTemplateAndWaitResult
-		dockerClient          *client.Client
-		err                   error
-		byohostContainerIDs   []string
-		agentLogFile1         = "/tmp/host-agent1.log"
-		agentLogFile2         = "/tmp/host-agent2.log"
-		pathToHostAgentBinary string
+		ctx                 context.Context
+		specName            = "quick-start"
+		namespace           *corev1.Namespace
+		clusterName         string
+		cancelWatches       context.CancelFunc
+		clusterResources    *clusterctl.ApplyClusterTemplateAndWaitResult
+		dockerClient        *client.Client
+		err                 error
+		byohostContainerIDs []string
+		agentLogFile1       = "/tmp/host-agent1.log"
+		agentLogFile2       = "/tmp/host-agent2.log"
 	)
 
 	BeforeEach(func() {
@@ -58,9 +49,6 @@ var _ = Describe("When BYOH joins existing cluster [PR-Blocking]", func() {
 		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
 
 		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
-
-		pathToHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent")
-		Expect(err).NotTo(HaveOccurred())
 
 		// set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
 		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)


### PR DESCRIPTION
It takes time to building host agent separately for every container. If we move it to suit-test.go to run it only once for entire e2e. It can save some time. My test is as followed:

Before do this:
-     e2e_test: time elapse: 4m38.405165171s
-     md_scale_test: time elapse: 11m2.787283875s
-     byohost_reuse_test: time elapse: 7m14.318728577s

After do this:
-     e2e_test: time elapse: 5m27.469585284s
-     md_scale_test: time elapse: 7m26.022867913s
-     byohost_reuse_test: time elapse: 6m51.386107789s

It can save more time for md_scale_test obviously.

Plus, I found some issue our code, fix it in meantime.
-     Writing byoh docker logs is not working, that's because we close file too early.
-     Should not let md_scale_test and byohost_reuse_test depend on the code of e2e_test.


Signed-off-by: chen hui <huchen@vmware.com>
