### PR TITLE
Add doc.go file to all packages

### DIFF
--- a/agent/cloudinit/doc.go
+++ b/agent/cloudinit/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cloudinit implements write_files and runcmd directives of cloudinit.
+package cloudinit

--- a/agent/installer/doc.go
+++ b/agent/installer/doc.go
@@ -1,0 +1,7 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package installer contains the implementation of Kubernetes components installation
+// and uninstallation for a given OS and Kubernetes version.
+// All the components are packaged as an ImgPkg bundle hosted on OCI registries.
+package installer

--- a/agent/installer/internal/algo/doc.go
+++ b/agent/installer/internal/algo/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package algo contains the interal implementation of the actual steps
+// required for installation and uninstallation of Kubernetes components.
+package algo

--- a/agent/reconciler/doc.go
+++ b/agent/reconciler/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package reconciler contains the host agent controller's reconcile implementation
+// that watches for ByoHost CRD
+package reconciler

--- a/agent/registration/doc.go
+++ b/agent/registration/doc.go
@@ -1,0 +1,6 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package registration creates a ByoHost CRD in the management cluster
+// This is equivalent to a ByoHost joining a capacity pool
+package registration

--- a/agent/version/doc.go
+++ b/agent/version/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package version defines the versioning scheme for byoh-agent downloadable binary
+package version

--- a/apis/infrastructure/v1beta1/doc.go
+++ b/apis/infrastructure/v1beta1/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package v1beta1 contains the v1beta1 API implementation.
+package v1beta1

--- a/controllers/infrastructure/doc.go
+++ b/controllers/infrastructure/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package controllers implements BYOH infra controllers.
+package controllers

--- a/test/e2e/doc.go
+++ b/test/e2e/doc.go
@@ -1,0 +1,5 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package e2e implements end to end testing of BYOH clusters.
+package e2e


### PR DESCRIPTION
Adding doc.go file so that our go docs are not completely empty. I know these are only one line descriptions and maybe we can do better. But maybe in subsequent iterations.

Fixes #275 