### PR TITLE
Before PR merging, run advance e2e test 

### DIFF
--- a/.github/workflows/advance-e2e.yaml
+++ b/.github/workflows/advance-e2e.yaml
@@ -1,12 +1,12 @@
 name: advance-e2e-suite
 
 on:
-  label:
+  pull_request:
     types: [labeled]
 
 jobs:
   e2e-before-merge:
-    if: ${{ github.event.label.name == 'merge not-run-e2e' }}
+      if: ${{ contains(github.event.pull_request.labels.*.name, 'ready-for-merge') }}
       runs-on: ubuntu-latest
       steps:
       - name: Checkout code

--- a/.github/workflows/advance-e2e.yml
+++ b/.github/workflows/advance-e2e.yml
@@ -1,5 +1,10 @@
 name: advance-e2e-suite
 
+on:
+  pull_request:
+    types: 
+      - ready_for_review
+      - review_requested
 
 jobs:
   e2e-before-merge:

--- a/.github/workflows/advance-e2e.yml
+++ b/.github/workflows/advance-e2e.yml
@@ -1,34 +1,30 @@
 name: advance-e2e-suite
 
 on:
-  push:
-    branches: [ main ]
   pull_request:
-    branches: [ main ]
-    types: 
-      - ready_for_review
-      - review_requested
+    types: [labeled]
 
 jobs:
   e2e-before-merge:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+    if: ${{ github.event.label.name == 'merge main' }}
+      runs-on: ubuntu-latest
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: 1.16
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
 
-    - name: Install ginkgo
-      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
+      - name: Install ginkgo
+        run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
 
-    - name: turn off swap
-      run: sudo swapoff -a
+      - name: turn off swap
+        run: sudo swapoff -a
 
-    - name: Set netfilter conntrack max
-      run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
+      - name: Set netfilter conntrack max
+        run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
 
-    - name: Run Before-PR-Merging e2e tests
-      run: yes | GINKGO_FOCUS="\[Before-PR-Merging\]" make test-e2e
+      - name: Run Before-PR-Merging e2e tests
+        run: yes | GINKGO_FOCUS="\[Before-PR-Merging\]" make test-e2e

--- a/.github/workflows/advance-e2e.yml
+++ b/.github/workflows/advance-e2e.yml
@@ -1,7 +1,10 @@
 name: advance-e2e-suite
 
 on:
+  push:
+    branches: [ main ]
   pull_request:
+    branches: [ main ]
     types: 
       - ready_for_review
       - review_requested

--- a/.github/workflows/advance-e2e.yml
+++ b/.github/workflows/advance-e2e.yml
@@ -1,7 +1,7 @@
 name: advance-e2e-suite
 
 on:
-  pull_request:
+  label:
     types: [labeled]
 
 jobs:

--- a/.github/workflows/advance-e2e.yml
+++ b/.github/workflows/advance-e2e.yml
@@ -1,0 +1,26 @@
+name: advance-e2e-suite
+
+
+jobs:
+  e2e-before-merge:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: Install ginkgo
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
+
+    - name: turn off swap
+      run: sudo swapoff -a
+
+    - name: Set netfilter conntrack max
+      run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
+
+    - name: Run Before-PR-Merging e2e tests
+      run: yes | GINKGO_FOCUS="\[Before-PR-Merging\]" make test-e2e

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -29,7 +29,7 @@ var (
 	dockerClient *client.Client
 )
 
-var _ = Describe("When BYO Host rejoins the capacity pool", func() {
+var _ = Describe("When BYO Host rejoins the capacity pool [Before-PR-Merging]", func() {
 
 	var (
 		ctx                   context.Context
@@ -74,7 +74,7 @@ var _ = Describe("When BYO Host rejoins the capacity pool", func() {
 		setDockerClient(client)
 
 		runner := ByoHostRunner{
-			Context:                   ctx,
+			Context:               ctx,
 			clusterConName:        clusterConName,
 			Namespace:             namespace.Name,
 			PathToHostAgentBinary: pathToHostAgentBinary,

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 )
 
-var _ = Describe("When testing MachineDeployment scale out/in", func() {
+var _ = Describe("When testing MachineDeployment scale out/in [Before-PR-Merging]", func() {
 
 	var (
 		ctx                    context.Context
@@ -72,13 +72,13 @@ var _ = Describe("When testing MachineDeployment scale out/in", func() {
 			byoHostName = fmt.Sprintf("byohost-%s", util.RandomString(6))
 
 			runner := ByoHostRunner{
-				Context:                   ctx,
+				Context:               ctx,
 				clusterConName:        clusterConName,
 				ByoHostName:           byoHostName,
 				Namespace:             namespace.Name,
 				PathToHostAgentBinary: pathToHostAgentBinary,
 				DockerClient:          dockerClient,
-				NetworkInterface: "kind",
+				NetworkInterface:      "kind",
 				bootstrapClusterProxy: bootstrapClusterProxy,
 				CommandArgs: map[string]string{
 					"--kubeconfig": "/mgmt.conf",


### PR DESCRIPTION
Currently we only run basic e2e test(e2e_test) for every commit.  After all comments on PR are sloved and just before merging, we should run advance e2e test(byohost_reuse_test+md_scale_test), and we should manually trigger this workflow for that. 

In order to achieve this, I create a new tag "ready-for-merge". After all comments are solved, please tag the PR with this new tag, the advance e2e test will be kickoff. Merge this PR only after the advance e2e test are passed


Signed-off-by: chen hui <huchen@vmware.com>
