### PR TITLE
Add feature gate support for SecureAccess to host agent

### DIFF
--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package feature
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -5,40 +8,11 @@ import (
 )
 
 const (
-	// Every feature gate should add method here following this template:
-	//
-	// // owner: @username
-	// // alpha: v1.X
-	// MyFeature featuregate.Feature = "MyFeature".
-
-	// MachinePool is a feature gate for MachinePool functionality.
-	//
-	// alpha: v0.3
-	// MachinePool featuregate.Feature = "MachinePool"
-
-	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
-	//
-	// alpha: v0.3
-	// beta: v0.4
-	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
-
-	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
-	//
-	// alpha: v0.4
-	// ClusterTopology featuregate.Feature = "ClusterTopology"
-
 	SecureAccess featuregate.Feature = "SecureAccess"
 )
 
 var (
-	// MutableGates is a mutable version of DefaultFeatureGate.
-	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
-	// Tests that need to modify featuregate gates for the duration of their test should use:
-	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-
-	// Gates is a shared global FeatureGate.
-	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
 	Gates featuregate.FeatureGate = MutableGates
 )
 
@@ -49,9 +23,5 @@ func init() {
 // defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	// Every feature should be initiated here:
-	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
-	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
-	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
 	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,0 +1,57 @@
+package feature
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v1.X
+	// MyFeature featuregate.Feature = "MyFeature".
+
+	// MachinePool is a feature gate for MachinePool functionality.
+	//
+	// alpha: v0.3
+	// MachinePool featuregate.Feature = "MachinePool"
+
+	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
+	//
+	// alpha: v0.3
+	// beta: v0.4
+	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
+
+	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
+	//
+	// alpha: v0.4
+	// ClusterTopology featuregate.Feature = "ClusterTopology"
+
+	SecureAccess featuregate.Feature = "SecureAccess"
+)
+
+var (
+	// MutableGates is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	// Tests that need to modify featuregate gates for the duration of their test should use:
+	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
+	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// Gates is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
+	Gates featuregate.FeatureGate = MutableGates
+)
+
+func init() {
+	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+}
+
+// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	// Every feature should be initiated here:
+	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
+	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
+	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
+	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -25,6 +25,7 @@ var _ = Describe("Help flag for host agent", func() {
 				"--skip-installation",
 				"--version",
 				"-v, --v",
+				"--feature-gates mapStringBool",
 			}
 		)
 

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -363,7 +363,6 @@ var _ = Describe("Agent", func() {
 			ctx              context.Context
 			err              error
 			hostName         string
-			agentLogFile     = "/tmp/agent-integration.log"
 			fakeDownloadPath = "fake-download-path"
 			runner           *e2e.ByoHostRunner
 			byoHostContainer *container.ContainerCreateCreatedBody

--- a/agent/main.go
+++ b/agent/main.go
@@ -96,10 +96,10 @@ func setupflags() {
 }
 
 func handleHostRegistration(k8sClient client.Client, hostName string, logger logr.Logger) (err error) {
+	registration.LocalHostRegistrar = &registration.HostRegistrar{K8sClient: k8sClient}
 	if feature.Gates.Enabled(feature.SecureAccess) {
 		logger.Info("secure access enabled, waiting for host to be registered by ByoAdmission Controller")
 	} else {
-		registration.LocalHostRegistrar = &registration.HostRegistrar{K8sClient: k8sClient}
 		err := registration.LocalHostRegistrar.Register(hostName, namespace, labels)
 		return err
 	}
@@ -108,7 +108,7 @@ func handleHostRegistration(k8sClient client.Client, hostName string, logger log
 
 func setupTemplateParser() *cloudinit.TemplateParser {
 	var templateParser *cloudinit.TemplateParser
-	if feature.Gates.Enabled(feature.SecureAccess) {
+	if registration.LocalHostRegistrar.ByoHostInfo.DefaultNetworkInterfaceName == "" {
 		templateParser = nil
 	} else {
 		templateParser = &cloudinit.TemplateParser{

--- a/agent/main.go
+++ b/agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/pflag"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/cloudinit"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/feature"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/installer"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/reconciler"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
@@ -90,6 +91,7 @@ func setupflags() {
 	for _, hiddenFlag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(hiddenFlag)
 	}
+	feature.MutableGates.AddFlag(pflag.CommandLine)
 }
 
 var (
@@ -189,6 +191,11 @@ func main() {
 		Recorder:     mgr.GetEventRecorderFor("hostagent-controller"),
 		K8sInstaller: k8sInstaller,
 	}
+
+	if feature.Gates.Enabled(feature.SecureAccess) {
+		logger.Info("secure access enabled")
+	}
+
 	if err = hostReconciler.SetupWithManager(context.TODO(), mgr); err != nil {
 		logger.Error(err, "unable to create controller")
 		return

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -1,4 +1,4 @@
-// Copyright 2021 VMware, Inc. All Rights Reserved.
+// Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
@@ -18,11 +18,11 @@ var (
 )
 
 func init() {
-	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+	runtime.Must(MutableGates.Add(defaultClusterAPIBYOHFeatureGates))
 }
 
 // defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
-var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+var defaultClusterAPIBYOHFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -21,7 +21,7 @@ func init() {
 	runtime.Must(MutableGates.Add(defaultClusterAPIBYOHFeatureGates))
 }
 
-// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// defaultClusterAPIBYOHFeatureGates consists of all known cluster-api-byoh feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIBYOHFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
+
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
@@ -13,7 +14,7 @@ const (
 
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-	Gates featuregate.FeatureGate = MutableGates
+	Gates        featuregate.FeatureGate        = MutableGates
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
+	k8s.io/component-base v0.22.2
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.22.2
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds feature-gate support for `SecureAccess` to host agent. Additionally,
- Offloads the agent registration process to the proposed `ByoAdmission Controller` when the `SecureAccess` flag is active.
- Updates the `hostReconciler` to delay network interface setup until host registration.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #428 
