### PR TITLE
Add feature flag support for SecureAccess to management cluster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY feature/ feature/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package feature
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -5,40 +8,11 @@ import (
 )
 
 const (
-	// Every feature gate should add method here following this template:
-	//
-	// // owner: @username
-	// // alpha: v1.X
-	// MyFeature featuregate.Feature = "MyFeature".
-
-	// MachinePool is a feature gate for MachinePool functionality.
-	//
-	// alpha: v0.3
-	// MachinePool featuregate.Feature = "MachinePool"
-
-	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
-	//
-	// alpha: v0.3
-	// beta: v0.4
-	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
-
-	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
-	//
-	// alpha: v0.4
-	// ClusterTopology featuregate.Feature = "ClusterTopology"
-
 	SecureAccess featuregate.Feature = "SecureAccess"
 )
 
 var (
-	// MutableGates is a mutable version of DefaultFeatureGate.
-	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
-	// Tests that need to modify featuregate gates for the duration of their test should use:
-	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-
-	// Gates is a shared global FeatureGate.
-	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
 	Gates featuregate.FeatureGate = MutableGates
 )
 
@@ -49,9 +23,5 @@ func init() {
 // defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	// Every feature should be initiated here:
-	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
-	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
-	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
 	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
+
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
@@ -13,7 +14,7 @@ const (
 
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-	Gates featuregate.FeatureGate = MutableGates
+	Gates        featuregate.FeatureGate        = MutableGates
 )
 
 func init() {

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,0 +1,57 @@
+package feature
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v1.X
+	// MyFeature featuregate.Feature = "MyFeature".
+
+	// MachinePool is a feature gate for MachinePool functionality.
+	//
+	// alpha: v0.3
+	// MachinePool featuregate.Feature = "MachinePool"
+
+	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
+	//
+	// alpha: v0.3
+	// beta: v0.4
+	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
+
+	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
+	//
+	// alpha: v0.4
+	// ClusterTopology featuregate.Feature = "ClusterTopology"
+
+	SecureAccess featuregate.Feature = "SecureAccess"
+)
+
+var (
+	// MutableGates is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	// Tests that need to modify featuregate gates for the duration of their test should use:
+	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
+	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// Gates is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
+	Gates featuregate.FeatureGate = MutableGates
+)
+
+func init() {
+	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+}
+
+// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	// Every feature should be initiated here:
+	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
+	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
+	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
+	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Help flag for host agent", func() {
 		var (
 			expectedOptions = []string{
 				"--downloadpath string",
+				"--feature-gates mapStringBool",
 				"--kubeconfig string",
 				"--label labelFlags",
 				"--metricsbindaddress string",

--- a/agent/main.go
+++ b/agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	pflag "github.com/spf13/pflag"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/cloudinit"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/feature"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/installer"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/reconciler"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
@@ -90,6 +91,7 @@ func setupflags() {
 	for _, hiddenFlag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(hiddenFlag)
 	}
+	feature.MutableGates.AddFlag(pflag.CommandLine)
 }
 
 var (
@@ -189,6 +191,11 @@ func main() {
 		Recorder:     mgr.GetEventRecorderFor("hostagent-controller"),
 		K8sInstaller: k8sInstaller,
 	}
+
+	if feature.Gates.Enabled(feature.SecureAccess) {
+		logger.Info("secure access enabled")
+	}
+
 	if err = hostReconciler.SetupWithManager(context.TODO(), mgr); err != nil {
 		logger.Error(err, "unable to create controller")
 		return

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byomachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byomachinetemplates.yaml
@@ -38,6 +38,8 @@ spec:
             description: ByoMachineTemplateSpec defines the desired state of ByoMachineTemplate
             properties:
               template:
+                description: ByoMachineTemplateResource defines the desired state
+                  of ByoMachineTemplateResource
                 properties:
                   spec:
                     description: Spec is the specification of the desired behavior

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
-        - "--feature-gates=MachinePool=${EXP_SECURE_ACCESS:=false}"
+        - "--feature-gates=SecureAccess=${SECURE_ACCESS:=false}"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--feature-gates SecureAccess=true"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
-        - "--feature-gates SecureAccess=true"
+        - "--feature-gates=MachinePool=${EXP_SECURE_ACCESS:=false}"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -1,0 +1,27 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package feature
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	SecureAccess featuregate.Feature = "SecureAccess"
+)
+
+var (
+	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+	Gates featuregate.FeatureGate = MutableGates
+)
+
+func init() {
+	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+}
+
+// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
+
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
@@ -13,7 +14,7 @@ const (
 
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-	Gates featuregate.FeatureGate = MutableGates
+	Gates        featuregate.FeatureGate        = MutableGates
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
+	k8s.io/component-base v0.22.2
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.22.2
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b

--- a/main.go
+++ b/main.go
@@ -21,7 +21,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
+	"github.com/spf13/pflag"
 	byohcontrollers "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/controllers/infrastructure"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/feature"
 
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	//+kubebuilder:scaffold:imports
@@ -54,7 +56,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.Parse()
+	feature.MutableGates.AddFlag(pflag.CommandLine)
+	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New())
 
@@ -140,6 +143,10 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+
+	if feature.Gates.Enabled(feature.SecureAccess) {
+		setupLog.Info("secure access enabled for management cluster")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -52,12 +52,11 @@ func init() {
 }
 
 func setupflags() {
-	klog.InitFlags(nil)
-
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	feature.MutableGates.AddFlag(pflag.CommandLine)
 }
 

--- a/main.go
+++ b/main.go
@@ -33,8 +33,11 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme               = runtime.NewScheme()
+	setupLog             = ctrl.Log.WithName("setup")
+	metricsAddr          string
+	enableLeaderElection bool
+	probeAddr            string
 )
 
 func init() {
@@ -48,15 +51,18 @@ func init() {
 	utilruntime.Must(admissionv1beta1.AddToScheme(scheme))
 }
 
-func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
+func setupflags() {
+	klog.InitFlags(nil)
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	feature.MutableGates.AddFlag(pflag.CommandLine)
+}
+
+func main() {
+	setupflags()
 	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New())


### PR DESCRIPTION
**What this PR does / why we need it**:
This is part of the effort to create a feature flag for experimental security features. This is parallel to #429, which introduces the same flag for the host agent. This PR does this for the controller in the management cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Partially fixes #428 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->