### PR TITLE
Handle bundle artifact naming changes

### DIFF
--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -46,7 +46,7 @@ var (
 
 const (
 	bundleLookupBaseRegistry = "projects.registry.vmware.com/cluster_api_provider_bringyourownhost"
-	BundleLookupTag          = "v0.1.0_alpha.2"
+	BundleLookupTag          = "v1.22.3"
 	K8sVersion               = "v1.22.3"
 )
 

--- a/agent/installer/bundle_downloader.go
+++ b/agent/installer/bundle_downloader.go
@@ -22,6 +22,7 @@ var (
 
 // bundleDownloader for downloading an OCI image.
 type bundleDownloader struct {
+	bundleType   bundleType
 	repoAddr     string
 	downloadPath string
 	logger       logr.Logger
@@ -65,7 +66,7 @@ func (bd *bundleDownloader) DownloadFromRepo(
 		return err
 	}
 
-	bundleDirPath := bd.GetBundleDirPath(k8sVersion, tag)
+	bundleDirPath := bd.GetBundleDirPath(k8sVersion)
 
 	// cache hit
 	if checkDirExist(bundleDirPath) {
@@ -130,16 +131,16 @@ func convertError(err error) error {
 }
 
 // GetBundleDirPath returns the path to directory containing the required bundle.
-func (bd *bundleDownloader) GetBundleDirPath(k8sVersion, tag string) string {
+func (bd *bundleDownloader) GetBundleDirPath(k8sVersion string) string {
 	// Not storing tag as a subdir of k8s because we can't atomically move
 	// the temp bundle dir to a non-existing dir.
 	// Using "-" instead of ":" because Windows doesn't like the latter
-	return fmt.Sprintf("%s-%s", filepath.Join(bd.getBundlePathWithRepo(), k8sVersion), tag)
+	return fmt.Sprintf("%s-%s", filepath.Join(bd.getBundlePathWithRepo(), string(bd.bundleType)), k8sVersion)
 }
 
 // GetBundleName returns the name of the bundle in normalized format.
 func GetBundleName(normalizedOsVersion string) string {
-	return strings.ToLower(fmt.Sprintf("byoh-bundle-%s", normalizedOsVersion))
+	return strings.ToLower(fmt.Sprintf("byoh-bundle-%s_k8s", normalizedOsVersion))
 }
 
 // getBundlePathWithRepo returns the path

--- a/agent/installer/bundle_downloader.go
+++ b/agent/installer/bundle_downloader.go
@@ -138,8 +138,8 @@ func (bd *bundleDownloader) GetBundleDirPath(k8sVersion, tag string) string {
 }
 
 // GetBundleName returns the name of the bundle in normalized format.
-func GetBundleName(normalizedOsVersion, k8sVersion string) string {
-	return strings.ToLower(fmt.Sprintf("byoh-bundle-%s_k8s_%s", normalizedOsVersion, k8sVersion))
+func GetBundleName(normalizedOsVersion string) string {
+	return strings.ToLower(fmt.Sprintf("byoh-bundle-%s", normalizedOsVersion))
 }
 
 // getBundlePathWithRepo returns the path
@@ -149,7 +149,7 @@ func (bd *bundleDownloader) getBundlePathWithRepo() string {
 
 // getBundleAddr returns the exact address to the bundle in the repo.
 func (bd *bundleDownloader) getBundleAddr(normalizedOsVersion, k8sVersion, tag string) string {
-	return fmt.Sprintf("%s/%s:%s", bd.repoAddr, GetBundleName(normalizedOsVersion, k8sVersion), tag)
+	return fmt.Sprintf("%s/%s:%s", bd.repoAddr, GetBundleName(normalizedOsVersion), tag)
 }
 
 // checkDirExist checks if a dirrectory exists.

--- a/agent/installer/bundle_downloader_test.go
+++ b/agent/installer/bundle_downloader_test.go
@@ -40,14 +40,14 @@ var _ = Describe("Byohost Installer Tests", func() {
 
 	BeforeEach(func() {
 		normalizedOsVersion = "Ubuntu_20.04.3_x64"
-		k8sVersion = "1.22"
+		k8sVersion = "v1.22.5"
 		repoAddr = ""
 		var err error
 		downloadPath, err = os.MkdirTemp("", "downloaderTest")
 		if err != nil {
 			log.Fatal(err)
 		}
-		bd = &bundleDownloader{repoAddr, downloadPath, logr.Discard()}
+		bd = &bundleDownloader{BundleTypeK8s, repoAddr, downloadPath, logr.Discard()}
 		mi = &mockImgpkg{}
 	})
 	AfterEach(func() {
@@ -93,12 +93,12 @@ var _ = Describe("Byohost Installer Tests", func() {
 				testTag,
 				mi.Get)
 			Expect(err).ShouldNot(HaveOccurred())
-			_, err = os.Stat(bd.GetBundleDirPath(k8sVersion, testTag))
+			_, err = os.Stat(bd.GetBundleDirPath(k8sVersion))
 			Expect(err).ShouldNot(HaveOccurred())
 			notExist := os.IsNotExist(err)
 			Expect(notExist).ShouldNot(BeTrue())
 
-			_, err = os.Stat(bd.GetBundleDirPath(k8sVersion+"a", testTag))
+			_, err = os.Stat(bd.GetBundleDirPath(k8sVersion + "a"))
 			Expect(err).Should(HaveOccurred())
 			notExist = os.IsNotExist(err)
 			Expect(notExist).Should(BeTrue())

--- a/agent/installer/cli-dev.go
+++ b/agent/installer/cli-dev.go
@@ -107,7 +107,7 @@ func listSupported() {
 	osFilters, osBundles := ListSupportedOS()
 	for i := range osFilters {
 		for _, k8s := range ListSupportedK8s(osBundles[i]) {
-			_, err = fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i]))
+			_, err = fmt.Fprintf(w, "%s\t %s\t%s:%s\n", osFilters[i], k8s, GetBundleName(osBundles[i]), k8s)
 			if err != nil {
 				klogger.Error(err, "Failed to write to tabwriter")
 			}
@@ -131,13 +131,13 @@ func runInstaller(install bool) {
 	var err error
 	if *osFlag != "" {
 		// Override current OS detection
-		i, err = newUnchecked(*osFlag, *cachePathFlag, klogger, &logPrinter{klogger})
+		i, err = newUnchecked(*osFlag, BundleTypeK8s, *cachePathFlag, klogger, &logPrinter{klogger})
 		if err != nil {
 			klogger.Error(err, "unable to create installer")
 			return
 		}
 	} else {
-		i, err = New(*cachePathFlag, klogger)
+		i, err = New(*cachePathFlag, BundleTypeK8s, klogger)
 		if err != nil {
 			klogger.Error(err, "unable to create installer")
 			return

--- a/agent/installer/cli-dev.go
+++ b/agent/installer/cli-dev.go
@@ -107,7 +107,7 @@ func listSupported() {
 	osFilters, osBundles := ListSupportedOS()
 	for i := range osFilters {
 		for _, k8s := range ListSupportedK8s(osBundles[i]) {
-			_, err = fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i], k8s))
+			_, err = fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i]))
 			if err != nil {
 				klogger.Error(err, "Failed to write to tabwriter")
 			}

--- a/agent/installer/cli-dev.go
+++ b/agent/installer/cli-dev.go
@@ -95,8 +95,13 @@ func listSupported() {
 			klogger.Error(err, "Failed to flush the tabwriter")
 		}
 	}()
-
-	_, err := fmt.Fprintf(w, "%s\t%s\t%s\n", "OS", "K8S Version", "BYOH Bundle Name")
+	_, err := fmt.Fprintf(w, "The corresponding bundles (particular to a patch version) should be pushed to the OCI registry of choice\n"+
+		"By default, BYOH uses projects.registry.vmware.com\n\n"+
+		"Note: It may happen that a specific patch version of a k8s minor release is not available in the OCI registry\n\n")
+	if err != nil {
+		klogger.Error(err, "Failed to write to tabwriter")
+	}
+	_, err = fmt.Fprintf(w, "%s\t%s\t%s\n", "OS", "K8S Version", "BYOH Bundle Name")
 	if err != nil {
 		klogger.Error(err, "Failed to write to tabwriter")
 	}

--- a/agent/installer/installer_test.go
+++ b/agent/installer/installer_test.go
@@ -16,13 +16,13 @@ var _ = Describe("Byohost Installer Tests", func() {
 
 	Context("When installer is created for unsupported OS", func() {
 		It("Should return error", func() {
-			_, err := newUnchecked("Ubuntu_99.04.3_x86-64", "", logr.Discard(), nil)
+			_, err := newUnchecked("Ubuntu_99.04.3_x86-64", BundleTypeK8s, "", logr.Discard(), nil)
 			Expect(err).Should(HaveOccurred())
 		})
 	})
 	Context("When installer is created with empty download path", func() {
 		It("Should return error", func() {
-			_, err := New("", logr.Discard())
+			_, err := New("", BundleTypeK8s, logr.Discard())
 			Expect(err).Should(HaveOccurred())
 		})
 	})
@@ -125,7 +125,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 })
 
 func NewPreviewInstaller(os string, ob algo.OutputBuilder) *installer {
-	i, err := newUnchecked(os, "", logr.Discard(), ob)
+	i, err := newUnchecked(os, BundleTypeK8s, "", logr.Discard(), ob)
 	if err != nil {
 		panic(err)
 	}

--- a/agent/main.go
+++ b/agent/main.go
@@ -199,7 +199,7 @@ func main() {
 		logger.Info("skip-installation flag set, skipping installer initialisation")
 	} else {
 		// increasing installer log level to 1, so that it wont be logged by default
-		k8sInstaller, err = installer.New(downloadpath, logger.V(1))
+		k8sInstaller, err = installer.New(downloadpath, installer.BundleTypeK8s, logger.V(1))
 		if err != nil {
 			logger.Error(err, "failed to instantiate installer")
 		}

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -190,6 +190,12 @@ The current list of supported tuples of OS, kubernetes Version, BYOH Bundle Name
 ./cli --list-supported
 ```
 An example output looks like:
+
+The corresponding bundles (particular to a patch version) should be pushed to the OCI registry of choice
+By default, BYOH uses projects.registry.vmware.com
+
+Note: It may happen that a specific patch version of a k8s minor release is not available in the OCI registry
+
 <table>
     <tr>
         <td>OS</td>
@@ -198,11 +204,23 @@ An example output looks like:
     </tr>
     <tr>
         <td>Ubuntu_20.04.*_x86-64</td>
-        <td>v1.22.3</td>
-        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s_v1.22.3</td>
+        <td>v1.21.*</td>
+        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.21.*</td>
+    </tr>
+        <tr>
+        <td>Ubuntu_20.04.*_x86-64</td>
+        <td>v1.22.*</td>
+        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.22.*</td>
+    </tr>
+        <tr>
+        <td>Ubuntu_20.04.*_x86-64</td>
+        <td>v1.23.*</td>
+        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.23.*</td>
     </tr>
 </table>
 The '*' in OS means that all Ubuntu 20.04 patches will be handled by this BYOH bundle.
+
+The '*' in the K8S Version means that the k8s minor release is supported but it may happen that a byoh bundle for a specific patch may not exist n the OCI registry,
 
 ## Pre-requisites
 As of writing this, the following packages must be pre-installed on the BYOH host:

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -95,7 +95,7 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.0.4/clusterctl-{OS}-{ARCH}"
-  BUNDLE_LOOKUP_TAG: "v0.1.0_alpha.2"
+  BUNDLE_LOOKUP_TAG: "v1.22.3"
   CONTROL_PLANE_ENDPOINT_IP: ""
 
 intervals:


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR will handle the newer BYOH Bundles naming convention i.e. `byoh-bundle-ubuntu_20.04.1_x86-64_<bundleType>:<k8sVersion>` where

`bundleType` - k8s
`k8sVersion` - example - v1.22.3 

This PR introduces
- `bundleType` type to support future use cases of various bundle types 
- handles `--list-supported` output for installer cli
```
The corresponding bundles (particular to a patch version) should be pushed to the OCI registry of choice
By default, BYOH uses projects.registry.vmware.com

Note: It may happen that a specific patch version of a k8s minor release is not available in the OCI registry

OS                      K8S Version     BYOH Bundle Name
---                     -----------     ----------------
Ubuntu_20.04.*_x86-64    v1.21.*        byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.21.*
Ubuntu_20.04.*_x86-64    v1.22.*        byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.22.*
Ubuntu_20.04.*_x86-64    v1.23.*        byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.23.*
```
**Which issue(s) this PR fixes**
fixes: #448 #414 

**Special notes for your reviewer**

- This is a backward-incompatible change.
- Naming still uses the ubuntu patch version i.e. `20.04.1`  to map any ubuntu OS 20.04 patch version to the mentioned artifact.