### PR TITLE
Wait for the host agent process to start in host agent integration tests

### DIFF
--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -157,6 +157,18 @@ var _ = Describe("Agent", func() {
 
 			output, _, err = runner.ExecByoDockerHost(byoHostContainer)
 			Expect(err).NotTo(HaveOccurred())
+
+			// wait until the agent process starts inside the byoh host container
+			Eventually(func() bool {
+				containerTop, _ := runner.DockerClient.ContainerTop(ctx, byoHostContainer.ID, []string{})
+				for _, proc := range containerTop.Processes {
+					if strings.Contains(proc[len(containerTop.Titles)-1], "agent") {
+						return true
+					}
+
+				}
+				return false
+			}).Should(BeTrue())
 		})
 
 		AfterEach(func() {
@@ -313,7 +325,7 @@ var _ = Describe("Agent", func() {
 						}
 					}
 					return corev1.ConditionFalse
-				}, 60).Should(Equal(corev1.ConditionTrue))
+				}, 100).Should(Equal(corev1.ConditionTrue)) // installing K8s components is a lengthy operation, setting the timeout to 100s
 			})
 		})
 	})

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Agent", func() {
 
 				}
 				return false
-			}).Should(BeTrue())
+			}, 60).Should(BeTrue())
 		})
 
 		AfterEach(func() {


### PR DESCRIPTION
Since we are running the host agent in the containers for integration
tests, the process is not started instantly sometimes and this causes
flakes in the tests. Adding a check to ensure the host agent process is
started and only then proceed with the tests

Signed-off-by: Nilanjan Daw <dawn@vmware.com>

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #438 
