### PR TITLE
Fix for bundle version in the installer CLI

### DIFF
--- a/agent/installer/cli-dev.go
+++ b/agent/installer/cli-dev.go
@@ -107,7 +107,7 @@ func listSupported() {
 	osFilters, osBundles := ListSupportedOS()
 	for i := range osFilters {
 		for _, k8s := range ListSupportedK8s(osBundles[i]) {
-			_, err = fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i], k8s))
+			_, err = fmt.Fprintf(w, "%s\t %s\t%s\n", osFilters[i], k8s, GetBundleName(osBundles[i], GetK8sBundle(k8s)))
 			if err != nil {
 				klogger.Error(err, "Failed to write to tabwriter")
 			}

--- a/agent/installer/installer.go
+++ b/agent/installer/installer.go
@@ -68,9 +68,9 @@ func getSupportedRegistry(ob algo.OutputBuilder) registry {
 		 */
 
 		// Match any patch version of the specified Major & Minor K8s version
-		reg.AddK8sFilter("v1.21.*")
-		reg.AddK8sFilter("v1.22.*")
-		reg.AddK8sFilter("v1.23.*")
+		reg.AddK8sFilter("v1.21.*", "v1.22")
+		reg.AddK8sFilter("v1.22.*", "v1.22")
+		reg.AddK8sFilter("v1.23.*", "v1.22")
 
 		// Match concrete os version to repository os version
 		reg.AddOsFilter("Ubuntu_20.04.*_x86-64", linuxDistro)

--- a/agent/installer/registry.go
+++ b/agent/installer/registry.go
@@ -8,6 +8,8 @@ import (
 	"regexp"
 )
 
+var k8sFilterBundleMap map[string]string
+
 type osk8sInstaller interface{}
 type k8sInstallerMap map[string]osk8sInstaller
 type osk8sInstallerMap map[string]k8sInstallerMap
@@ -55,8 +57,15 @@ func (r *registry) AddOsFilter(osFilter, osBundle string) {
 	r.filterOSBundleList = append(r.filterOSBundleList, filterOsBundlePair{osFilter: osFilter, osBundle: osBundle})
 }
 
-func (r *registry) AddK8sFilter(k8sFilter string) {
+func (r *registry) AddK8sFilter(k8sFilter, k8sBundle string) {
 	r.filterK8sBundleList = append(r.filterK8sBundleList, filterK8sBundle{k8sFilter: k8sFilter})
+	if k8sFilterBundleMap == nil {
+		k8sFilterBundleMap = make(map[string]string)
+	}
+	k8sFilterBundleMap[k8sFilter] = k8sBundle
+}
+func GetK8sBundle(k8sFilter string) string {
+	return k8sFilterBundleMap[k8sFilter]
 }
 
 // ListOS returns a list of OSes supported by the registry

--- a/agent/installer/registry_test.go
+++ b/agent/installer/registry_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 
 			r.AddOsFilter("ubuntu.*", "ubuntu")
 			r.AddOsFilter("rhel.*", "rhel")
-			r.AddK8sFilter("v1.22.*")
+			r.AddK8sFilter("v1.22.*", "v1.22")
 
 			inst, osBundle := r.GetInstaller("ubuntu-1", "v1.22.1")
 			Expect(inst).To(Equal(dummy122))
@@ -70,7 +70,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 			// Bundle OS does not match filter OS
 			r.AddBundleInstaller("UBUNTU", "v1.22.*", dummy122)
 			r.AddOsFilter("ubuntu.*", "UBUNTU")
-			r.AddK8sFilter("v1.22.*")
+			r.AddK8sFilter("v1.22.*", "v1.22")
 
 			inst, osBundle := r.GetInstaller("ubuntu-1", "v1.22.1")
 			Expect(inst).To(Equal(dummy122))


### PR DESCRIPTION
Made small changes so the CLI shows correct bundle version.
Made a map from k8s filter to k8s bundle (this is in order to easily output correct bundle for example 1.23.* -> 1.22)
Made changes to installer.go and the registry tests to accommodate the added second argument to the function.