### PR TITLE
Update version information in HostAgent binary

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.16
 
       - name: Build Release Artifacts
-        run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ github.ref_name }}" AGENT_BINARY_VERSION="${{ github.ref_name }}" make build-release-artifacts
+        run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ github.ref_name }}" make build-release-artifacts
 
       - name: Publish Release
         uses: softprops/action-gh-release@v1

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY feature/ feature/
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go

--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,8 @@ GINKGO := $(TOOLS_BIN_DIR)/ginkgo
 
 BYOH_TEMPLATES := $(REPO_ROOT)/test/e2e/data/infrastructure-provider-byoh
 
-LDFLAGS=-w -s
+LDFLAGS := -w -s $(shell hack/version.sh)
 STATIC=-extldflags '-static'
-AGENT_BINARY_VERSION ?= dev
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -201,9 +200,7 @@ kustomize: ## Download kustomize locally if necessary.
 	$(call go-get-tool,$(KUSTOMIZE),sigs.k8s.io/kustomize/kustomize/v3@v3.9.1)
 
 host-agent-binaries: ## Builds the binaries for the host-agent
-	RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 GOLDFLAGS="$(LDFLAGS) $(STATIC) \
-	-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.Version=${AGENT_BINARY_VERSION}' \
-	-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.BuildDate=$(shell date -u +\"%Y-%m-%dT%H:%M:%SZ\")'" \
+	RELEASE_BINARY=./byoh-hostagent GOOS=linux GOARCH=amd64 GOLDFLAGS="$(LDFLAGS) $(STATIC)" \
 	HOST_AGENT_DIR=./$(HOST_AGENT_DIR) $(MAKE) host-agent-binary
 
 host-agent-binary: $(RELEASE_DIR)

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,3 +1,6 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package feature
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -5,40 +8,11 @@ import (
 )
 
 const (
-	// Every feature gate should add method here following this template:
-	//
-	// // owner: @username
-	// // alpha: v1.X
-	// MyFeature featuregate.Feature = "MyFeature".
-
-	// MachinePool is a feature gate for MachinePool functionality.
-	//
-	// alpha: v0.3
-	// MachinePool featuregate.Feature = "MachinePool"
-
-	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
-	//
-	// alpha: v0.3
-	// beta: v0.4
-	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
-
-	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
-	//
-	// alpha: v0.4
-	// ClusterTopology featuregate.Feature = "ClusterTopology"
-
 	SecureAccess featuregate.Feature = "SecureAccess"
 )
 
 var (
-	// MutableGates is a mutable version of DefaultFeatureGate.
-	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
-	// Tests that need to modify featuregate gates for the duration of their test should use:
-	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-
-	// Gates is a shared global FeatureGate.
-	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
 	Gates featuregate.FeatureGate = MutableGates
 )
 
@@ -49,9 +23,5 @@ func init() {
 // defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
 // To add a new feature, define a key for it above and add it here.
 var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	// Every feature should be initiated here:
-	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
-	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
-	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
 	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
+
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
@@ -13,7 +14,7 @@ const (
 
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-	Gates featuregate.FeatureGate = MutableGates
+	Gates        featuregate.FeatureGate        = MutableGates
 )
 
 func init() {

--- a/agent/feature/feature.go
+++ b/agent/feature/feature.go
@@ -1,0 +1,57 @@
+package feature
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	// Every feature gate should add method here following this template:
+	//
+	// // owner: @username
+	// // alpha: v1.X
+	// MyFeature featuregate.Feature = "MyFeature".
+
+	// MachinePool is a feature gate for MachinePool functionality.
+	//
+	// alpha: v0.3
+	// MachinePool featuregate.Feature = "MachinePool"
+
+	// ClusterResourceSet is a feature gate for the ClusterResourceSet functionality.
+	//
+	// alpha: v0.3
+	// beta: v0.4
+	// ClusterResourceSet featuregate.Feature = "ClusterResourceSet"
+
+	// ClusterTopology is a feature gate for the ClusterClass and managed topologies functionality.
+	//
+	// alpha: v0.4
+	// ClusterTopology featuregate.Feature = "ClusterTopology"
+
+	SecureAccess featuregate.Feature = "SecureAccess"
+)
+
+var (
+	// MutableGates is a mutable version of DefaultFeatureGate.
+	// Only top-level commands/options setup and the k8s.io/component-base/featuregate/testing package should make use of this.
+	// Tests that need to modify featuregate gates for the duration of their test should use:
+	//   defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.<FeatureName>, <value>)()
+	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+
+	// Gates is a shared global FeatureGate.
+	// Top-level commands/options setup that needs to modify this featuregate gate should use DefaultMutableFeatureGate.
+	Gates featuregate.FeatureGate = MutableGates
+)
+
+func init() {
+	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+}
+
+// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	// Every feature should be initiated here:
+	// MachinePool:        {Default: false, PreRelease: featuregate.Alpha},
+	// ClusterResourceSet: {Default: true, PreRelease: featuregate.Beta},
+	// ClusterTopology:    {Default: false, PreRelease: featuregate.Alpha},
+	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -18,6 +18,7 @@ var _ = Describe("Help flag for host agent", func() {
 		var (
 			expectedOptions = []string{
 				"--downloadpath string",
+				"--feature-gates mapStringBool",
 				"--kubeconfig string",
 				"--label labelFlags",
 				"--metricsbindaddress string",

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -325,29 +325,47 @@ var _ = Describe("Agent", func() {
 		BeforeEach(func() {
 			date, err := exec.Command("date").Output()
 			Expect(err).NotTo(HaveOccurred())
+
+			version.GitMajor = "0"
+			version.GitMinor = "1"
+			version.GitVersion = "v0.1.0-79-42e700c78428bb-dirty"
+			version.GitCommit = "42e700c78428bb4c2096a85f5641565375d6"
+			version.GitTreeState = "dirty"
 			version.BuildDate = string(date)
-			version.Version = "v1.2.3"
-			ldflags := fmt.Sprintf("-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.Version=%s'"+
-				" -X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.BuildDate=%s'", version.Version, version.BuildDate)
-			tmpHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent", "-ldflags", ldflags)
+
+			ldflags := fmt.Sprintf("-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.GitMajor=%s'"+
+				"-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.GitMinor=%s'"+
+				"-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.GitVersion=%s'"+
+				"-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.GitCommit=%s'"+
+				"-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.GitTreeState=%s'"+
+				"-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.BuildDate=%s'",
+				version.GitMajor, version.GitMinor, version.GitVersion, version.GitCommit, version.GitTreeState, version.BuildDate)
+
+			tmpHostAgentBinary, err = gexec.Build("github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent", "-ldflags", string(ldflags))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		AfterEach(func() {
+			version.GitMajor = ""
+			version.GitMinor = ""
+			version.GitVersion = ""
+			version.GitCommit = ""
+			version.GitTreeState = ""
 			version.BuildDate = ""
-			version.Version = ""
 			tmpHostAgentBinary = ""
 		})
 
 		It("Shows the appropriate version of the agent", func() {
 			expectedStruct := version.Info{
-				Major:     "1",
-				Minor:     "2",
-				Patch:     "3",
-				BuildDate: version.BuildDate,
-				GoVersion: runtime.Version(),
-				Compiler:  runtime.Compiler,
-				Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+				Major:        "0",
+				Minor:        "1",
+				GitVersion:   "v0.1.0-79-42e700c78428bb-dirty",
+				GitCommit:    "42e700c78428bb4c2096a85f5641565375d6",
+				GitTreeState: "dirty",
+				BuildDate:    version.BuildDate,
+				GoVersion:    runtime.Version(),
+				Compiler:     runtime.Compiler,
+				Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 			}
 			expected := fmt.Sprintf("byoh-hostagent version: %#v\n", expectedStruct)
 			out, err := exec.Command(tmpHostAgentBinary, "--version").Output()

--- a/agent/main.go
+++ b/agent/main.go
@@ -12,6 +12,7 @@ import (
 
 	pflag "github.com/spf13/pflag"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/cloudinit"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/feature"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/installer"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/reconciler"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
@@ -90,6 +91,7 @@ func setupflags() {
 	for _, hiddenFlag := range hiddenFlags {
 		_ = pflag.CommandLine.MarkHidden(hiddenFlag)
 	}
+	feature.MutableGates.AddFlag(pflag.CommandLine)
 }
 
 var (
@@ -189,6 +191,11 @@ func main() {
 		Recorder:     mgr.GetEventRecorderFor("hostagent-controller"),
 		K8sInstaller: k8sInstaller,
 	}
+
+	if feature.Gates.Enabled(feature.SecureAccess) {
+		logger.Info("secure access enabled")
+	}
+
 	if err = hostReconciler.SetupWithManager(context.TODO(), mgr); err != nil {
 		logger.Error(err, "unable to create controller")
 		return

--- a/agent/version/version.go
+++ b/agent/version/version.go
@@ -6,62 +6,41 @@ package version
 import (
 	"fmt"
 	"runtime"
-	"strings"
 )
 
 var (
-	Version   string
-	BuildDate string
-)
-
-const (
-	Dev          = "dev"
-	GitTagLength = 3
+	GitMajor     string // major version, always numeric
+	GitMinor     string // minor version, numeric possibly followed by "+"
+	GitVersion   string // semantic version, derived by build scripts
+	GitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
+	GitTreeState string // state of git tree, either "clean" or "dirty"
+	BuildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
 )
 
 // Info exposes information about the version used for the current running code.
 type Info struct {
-	Major     string `json:"major,omitempty"`
-	Minor     string `json:"minor,omitempty"`
-	Patch     string `json:"patch,omitempty"`
-	BuildDate string `json:"BuildDate,omitempty"`
-	GoVersion string `json:"goVersion,omitempty"`
-	Platform  string `json:"platform,omitempty"`
-	Compiler  string `json:"compiler,omitempty"`
+	Major        string `json:"major,omitempty"`
+	Minor        string `json:"minor,omitempty"`
+	GitVersion   string `json:"gitVersion,omitempty"`
+	GitCommit    string `json:"gitCommit,omitempty"`
+	GitTreeState string `json:"gitTreeState,omitempty"`
+	BuildDate    string `json:"buildDate,omitempty"`
+	GoVersion    string `json:"goVersion,omitempty"`
+	Compiler     string `json:"compiler,omitempty"`
+	Platform     string `json:"platform,omitempty"`
 }
 
 // Get returns an Info object with all the information about the current running code.
 func Get() Info {
-	var major, minor, patch string
-	extractVersion(&major, &minor, &patch)
 	return Info{
-		Major:     major,
-		Minor:     minor,
-		Patch:     patch,
-		BuildDate: BuildDate,
-		GoVersion: runtime.Version(),
-		Compiler:  runtime.Compiler,
-		Platform:  fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Major:        GitMajor,
+		Minor:        GitMinor,
+		GitVersion:   GitVersion,
+		GitCommit:    GitCommit,
+		GitTreeState: GitTreeState,
+		BuildDate:    BuildDate,
+		GoVersion:    runtime.Version(),
+		Compiler:     runtime.Compiler,
+		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
 	}
-}
-
-func extractVersion(major, minor, patch *string) {
-	if Version == Dev {
-		*major = Dev
-		return
-	}
-
-	version := strings.Split(Version, ".")
-	if len(version) != GitTagLength {
-		return
-	}
-
-	// The git tag is preceded by a 'v', eg. v1.2.3
-	if len(version[0]) != 2 || version[0][0:1] != "v" {
-		return
-	}
-
-	*major = version[0][1:2]
-	*minor = version[1]
-	*patch = version[2]
 }

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
-        - "--feature-gates=MachinePool=${EXP_SECURE_ACCESS:=false}"
+        - "--feature-gates=SecureAccess=${SECURE_ACCESS:=false}"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,6 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
+        - "--feature-gates SecureAccess=true"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -28,7 +28,7 @@ spec:
         args:
         - --enable-leader-election
         - "--metrics-bind-addr=127.0.0.1:8080"
-        - "--feature-gates SecureAccess=true"
+        - "--feature-gates=MachinePool=${EXP_SECURE_ACCESS:=false}"
         image: gcr.io/k8s-staging-cluster-api/cluster-api-byoh-controller:latest
         name: manager
         resources:

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -1,0 +1,27 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package feature
+import (
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/featuregate"
+)
+
+const (
+	SecureAccess featuregate.Feature = "SecureAccess"
+)
+
+var (
+	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
+	Gates featuregate.FeatureGate = MutableGates
+)
+
+func init() {
+	runtime.Must(MutableGates.Add(defaultClusterAPIFeatureGates))
+}
+
+// defaultClusterAPIFeatureGates consists of all known cluster-api-specific feature keys.
+// To add a new feature, define a key for it above and add it here.
+var defaultClusterAPIFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
+}

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 package feature
+
 import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/featuregate"
@@ -13,7 +14,7 @@ const (
 
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
-	Gates featuregate.FeatureGate = MutableGates
+	Gates        featuregate.FeatureGate        = MutableGates
 )
 
 func init() {

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
+	k8s.io/component-base v0.22.2
 	k8s.io/klog v1.0.0
 	k8s.io/kubectl v0.22.2
 	k8s.io/utils v0.0.0-20210930125809-cb0fa318a74b

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+version::get_version_vars() {
+    # shellcheck disable=SC1083
+    GIT_COMMIT="$(git rev-parse HEAD^{commit})"
+
+    if git_status=$(git status --porcelain 2>/dev/null) && [[ -z ${git_status} ]]; then
+        GIT_TREE_STATE="clean"
+    else
+        GIT_TREE_STATE="dirty"
+    fi
+
+    # stolen from sigs.k8s.io/cluster-api/hack/version.sh
+    # Use git describe to find the version based on annotated tags.
+    # TODO: is '--tags' flag required?
+    if [[ -n ${GIT_VERSION-} ]] || GIT_VERSION=$(git describe --tags --abbrev=14 --match "v[0-9]*" 2>/dev/null); then
+        # This translates the "git describe" to an actual semver.org
+        # compatible semantic version that looks something like this:
+        #   v1.1.0-alpha.0.6+84c76d1142ea4d
+        #
+        # TODO: We continue calling this "git version" because so many
+        # downstream consumers are expecting it there.
+        # shellcheck disable=SC2001
+        DASHES_IN_VERSION=$(echo "${GIT_VERSION}" | sed "s/[^-]//g")
+        if [[ "${DASHES_IN_VERSION}" == "---" ]] ; then
+            # We have distance to subversion (v1.1.0-subversion-1-gCommitHash)
+            # shellcheck disable=SC2001
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-\([0-9]\{1,\}\)-g\([0-9a-f]\{14\}\)$/.\1\-\2/")
+        elif [[ "${DASHES_IN_VERSION}" == "--" ]] ; then
+            # We have distance to base tag (v1.1.0-1-gCommitHash)
+            # shellcheck disable=SC2001
+            GIT_VERSION=$(echo "${GIT_VERSION}" | sed "s/-g\([0-9a-f]\{14\}\)$/-\1/")
+        fi
+        if [[ "${GIT_TREE_STATE}" == "dirty" ]]; then
+            # git describe --dirty only considers changes to existing files, but
+            # that is problematic since new untracked .go files affect the build,
+            # so use our idea of "dirty" from git status instead.
+            GIT_VERSION+="-dirty"
+        fi
+
+
+        # Try to match the "git describe" output to a regex to try to extract
+        # the "major" and "minor" versions and whether this is the exact tagged
+        # version or whether the tree is between two tagged versions.
+        if [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?([-].*)?([+].*)?$ ]]; then
+            GIT_MAJOR=${BASH_REMATCH[1]}
+            GIT_MINOR=${BASH_REMATCH[2]}
+        fi
+
+        # If GIT_VERSION is not a valid Semantic Version, then refuse to build.
+        if ! [[ "${GIT_VERSION}" =~ ^v([0-9]+)\.([0-9]+)(\.[0-9]+)?(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "GIT_VERSION should be a valid Semantic Version. Current value: ${GIT_VERSION}"
+            echo "Please see more details here: https://semver.org"
+            exit 1
+        fi
+    fi
+
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+    # TODO: Is release commit required?
+    GIT_RELEASE_COMMIT=$(git rev-list -n 1  "${GIT_RELEASE_TAG}")
+}
+
+# stolen from sigs.k8s.io/cluster-api/hack/version.sh and modified
+# Prints the value that needs to be passed to the -ldflags parameter of go build
+version::ldflags() {
+    version::get_version_vars
+
+    local -a ldflags
+    function add_ldflag() {
+        local key=${1}
+        local val=${2}
+        ldflags+=(
+            "-X 'github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/version.${key}=${val}'"
+        )
+    }
+
+    add_ldflag "GitMajor" "${GIT_MAJOR}"
+    add_ldflag "GitMinor" "${GIT_MINOR}"
+    add_ldflag "GitVersion" "${GIT_VERSION}"
+    add_ldflag "GitCommit" "${GIT_COMMIT}"
+    add_ldflag "GitTreeState" "${GIT_TREE_STATE}"
+    add_ldflag "BuildDate" "$(date ${SOURCE_DATE_EPOCH:+"--date=@${SOURCE_DATE_EPOCH}"} -u +'%Y-%m-%dT%H:%M:%SZ')"
+    add_ldflag "GitReleaseCommit" "${GIT_RELEASE_COMMIT}"
+
+    # The -ldflags parameter takes a single string, so join the output.
+    echo "${ldflags[*]-}"
+}
+
+version::ldflags

--- a/main.go
+++ b/main.go
@@ -21,7 +21,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
+	"github.com/spf13/pflag"
 	byohcontrollers "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/controllers/infrastructure"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/feature"
 
 	infrastructurev1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	//+kubebuilder:scaffold:imports
@@ -54,7 +56,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.Parse()
+	feature.MutableGates.AddFlag(pflag.CommandLine)
+	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New())
 
@@ -140,6 +143,10 @@ func main() {
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
+	}
+
+	if feature.Gates.Enabled(feature.SecureAccess) {
+		setupLog.Info("secure access enabled for management cluster")
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -52,12 +52,11 @@ func init() {
 }
 
 func setupflags() {
-	klog.InitFlags(nil)
-
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
+	pflag.CommandLine.AddGoFlagSet(flag.CommandLine)
 	feature.MutableGates.AddFlag(pflag.CommandLine)
 }
 

--- a/main.go
+++ b/main.go
@@ -33,8 +33,11 @@ import (
 )
 
 var (
-	scheme   = runtime.NewScheme()
-	setupLog = ctrl.Log.WithName("setup")
+	scheme               = runtime.NewScheme()
+	setupLog             = ctrl.Log.WithName("setup")
+	metricsAddr          string
+	enableLeaderElection bool
+	probeAddr            string
 )
 
 func init() {
@@ -48,15 +51,18 @@ func init() {
 	utilruntime.Must(admissionv1beta1.AddToScheme(scheme))
 }
 
-func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
+func setupflags() {
+	klog.InitFlags(nil)
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	feature.MutableGates.AddFlag(pflag.CommandLine)
+}
+
+func main() {
+	setupflags()
 	pflag.Parse()
 
 	ctrl.SetLogger(klogr.New())


### PR DESCRIPTION
**What this PR does / why we need it**:
The version flag in the host agent binary displays the major, minor and patch versions. 
This PR introduces the following flags, similar to kubectl or clusterctl, and removes the patch field from version information.
```
$ ./bin/byoh-hostagent-linux-amd64 --version
byoh-hostagent version: version.Info{Major:"0", Minor:"1", GitVersion:"v0.1.0-79-42e700c78428bb-dirty", GitCommit:"42e700c78428bb4c2096a85f5641565375d666d0", GitTreeState:"dirty", BuildDate:"2022-03-23T12:29:43Z", GoVersion:"go1.16.6", Compiler:"gc", Platform:"linux/amd64"}
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #436 

**Additional information**
Changes:
- **.github/workflows/draft-release.yaml**: Now we extract version from the `hack/version.sh` script so no need for `AGENT_BINARY_VERSION`.
- **Makefile**: Now we use `ldflags` that are generated from the version.sh script.
- **agent/host_agent_test.go**: Tests for the agent version are changed according to the new format.
- **agent/version/version.go**: All the new required fields are introduced. We take the values of these fields from the variables generated by `ldflags` during building the binary. 
- **agent/version/version_test.go**: The tests for version.go. We build a fake binary and check its version info based on the given ldflags and compare these values. Due to the overhead of building and testing continuously, only 2 corner cases are checked which should suffice for all the cases.
- **/hack/version.sh**: The script with all the logic to assign values for the different fields in the ldflags. It uses `git describe` to extract all the information required for different fields. This is taken form `sigs.k8s.io/cluster-api/hack/version.sh`. 


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->