### PR TITLE
Update k8s version in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,8 @@ RELEASE_DIR := _dist
 
 # Image URL to use all building/pushing image targets
 IMG ?= ${STAGING_REGISTRY}/${IMAGE_NAME}:${TAG}
-BYOH_BASE_IMG = byoh/node:v1.22.3
-BYOH_BASE_IMG_DEV = byoh-dev/node:v1.22.3
+BYOH_BASE_IMG = byoh/node:e2e
+BYOH_BASE_IMG_DEV = byoh/node:dev
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 

--- a/agent/installer/bundle_builder/ingredients/deb/Dockerfile
+++ b/agent/installer/bundle_builder/ingredients/deb/Dockerfile
@@ -8,12 +8,12 @@
 # 2. Run the image
 #
 
-ARG BASE_IMAGE=ubuntu:18.04
+ARG BASE_IMAGE=ubuntu:20.04
 FROM $BASE_IMAGE as build
 
 # Override to download other version
-ENV CONTAINERD_VERSION=1.5.7
-ENV KUBERNETES_VERSION=1.21.2-00
+ENV CONTAINERD_VERSION=1.6.0
+ENV KUBERNETES_VERSION=1.23.5-00
 ENV ARCH=amd64
 
 RUN apt-get update \

--- a/agent/installer/bundle_builder/ingredients/deb/download.sh
+++ b/agent/installer/bundle_builder/ingredients/deb/download.sh
@@ -22,4 +22,4 @@ echo Update apt package index, install kubelet, kubeadm and kubectl
 sudo apt-get update
 sudo apt-get download {kubelet,kubeadm,kubectl}:$ARCH=$KUBERNETES_VERSION
 sudo apt-get download kubernetes-cni:$ARCH=0.8.7-00
-sudo apt-get download cri-tools:$ARCH=1.19.0-00
+sudo apt-get download cri-tools:$ARCH=1.23.0-00

--- a/docs/BYOHDockerFileDev
+++ b/docs/BYOHDockerFileDev
@@ -16,7 +16,7 @@ RUN echo "Installing kubectl kubeadm kubelet" \
     && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && apt-get update \
     && apt-get install -y linux-image-$(uname -r) \
-    && apt-get install -y kubelet=1.22.3-00 kubeadm=1.22.3-00 kubectl=1.22.3-00 \
+    && apt-get install -y kubelet=1.23.4-00 kubeadm=1.23.4-00 kubectl=1.23.4-00 \
     && apt-mark hold containerd kubelet kubeadm kubectl \
     && apt-get clean \
     && systemctl enable kubelet.service \

--- a/docs/BYOHDockerFileDev
+++ b/docs/BYOHDockerFileDev
@@ -16,7 +16,7 @@ RUN echo "Installing kubectl kubeadm kubelet" \
     && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && apt-get update \
     && apt-get install -y linux-image-$(uname -r) \
-    && apt-get install -y kubelet=1.23.4-00 kubeadm=1.23.4-00 kubectl=1.23.4-00 \
+    && apt-get install -y kubelet=1.23.5-00 kubeadm=1.23.5-00 kubectl=1.23.5-00 \
     && apt-mark hold containerd kubelet kubeadm kubectl \
     && apt-get clean \
     && systemctl enable kubelet.service \

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -95,7 +95,7 @@ Once the image is ready, lets start 2 docker containers for our deployment. One 
 for i in {1..2}
 do
   echo "Creating docker container named host$i"
-  docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh-dev/node:v1.22.3
+  docker run --detach --tty --hostname host$i --name host$i --privileged --security-opt seccomp=unconfined --tmpfs /tmp --tmpfs /run --volume /var --volume /lib/modules:/lib/modules:ro --network kind byoh/node:dev
 done
 ```
 
@@ -126,8 +126,8 @@ $ cat /etc/hosts
 ```
 
 If you are trying this on your own hosts, then for each host
-1. Download the [byoh-hostagent-linux-amd64](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.1.0/byoh-hostagent-linux-amd64)
-2. Copy the management cluster `kubeconfig` file as `management-cluster.conf`
+1. Download the [byoh-hostagent-linux-amd64](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/releases/download/v0.1.1/byoh-hostagent-linux-amd64)
+2. Copy the management cluster `kubeconfig` file as `management.conf`
 3. Start the agent 
 ```shell
 ./byoh-hostagent-linux-amd64 -kubeconfig management-cluster.conf > byoh-agent.log 2>&1 &
@@ -209,8 +209,23 @@ Generate the cluster.yaml for workload cluster
 
 Inspect and make any changes
 ```shell
-vi cluster.yaml
-```
+# for vms as byohosts
+$ BUNDLE_LOOKUP_TAG=v1.23.5 CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
+    --infrastructure byoh \
+    --kubernetes-version v1.23.5 \
+    --control-plane-machine-count 1 \
+    --worker-machine-count 1 > cluster.yaml
+
+# for docker hosts use the --flavor argument
+$ BUNDLE_LOOKUP_TAG=v1.23.5 CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
+    --infrastructure byoh \
+    --kubernetes-version v1.23.5 \
+    --control-plane-machine-count 1 \
+    --worker-machine-count 1 \
+    --flavor docker > cluster.yaml
+
+# Inspect and make any changes
+$ vi cluster.yaml
 
 Create the workload cluster in the current namespace on the management cluster
 ```shell
@@ -240,7 +255,7 @@ after that you should see your nodes turn into ready:
 ```shell
 $ KUBECONFIG=byoh-cluster.kubeconfig kubectl get nodes
 NAME                                                          STATUS     ROLES    AGE   VERSION
-byoh-cluster-8siai8                                           Ready      master   5m   v1.22.3
+byoh-cluster-8siai8                                           Ready      master   5m   v1.23.4
 
 ```
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -255,7 +255,7 @@ after that you should see your nodes turn into ready:
 ```shell
 $ KUBECONFIG=byoh-cluster.kubeconfig kubectl get nodes
 NAME                                                          STATUS     ROLES    AGE   VERSION
-byoh-cluster-8siai8                                           Ready      master   5m   v1.23.4
+byoh-cluster-8siai8                                           Ready      master   5m   v1.23.5
 
 ```
 

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -261,14 +261,14 @@ This step describes providing custom kubernetes host components. They can be cop
 
 ```shell
 # Build a BYOH bundle and publish it to an OCI-compliant repo
-docker run --rm -v `pwd`/byoh-ingredients-download:/ingredients --env BUILD_ONLY=0 build-push-bundle <REPO>/<BYOH Bundle name>
+docker run --rm -v `pwd`/byoh-ingredients-download:/ingredients --env BUILD_ONLY=0 byoh-build-push-bundle <REPO>/<BYOH Bundle name>
 ```
 
 The specified above BYOH Bundle name must match one of the [Supported OS and kubernetes BYOH bundle names](##supported-OS-and-kubernetes)
 
 ```shell
 # You can also build a tarball of the bundle without publishing. This will create a bundler.tar in the current directory and can be used for custom pushing
-docker run --rm -v `pwd`/byoh-ingredients-download:/ingredients -v`pwd`:/bundle --env BUILD_ONLY=1 build-push-bundle
+docker run --rm -v `pwd`/byoh-ingredients-download:/ingredients -v`pwd`:/bundle --env BUILD_ONLY=1 byoh-build-push-bundle
 ```
 
 ```shell

--- a/hack/getting_started.sh
+++ b/hack/getting_started.sh
@@ -525,7 +525,7 @@ It locally will change the following host config
 
 export PATH=/snap/bin:${PATH}
 byohImageName="byoh/node"
-byohImageTag="v1.22.3"
+byohImageTag="e2e"
 managerClusterName="kind-byoh"
 workerClusterName="worker-byoh"
 controlPlaneEndPointIp=""
@@ -537,7 +537,7 @@ manageClusterConfFile="${HOME}/.kube/management-cluster.conf"
 kubeConfigFile=/tmp/byoh-cluster-kubeconfig
 reposDir=$(dirname $0)/../
 byohBinaryFile=${reposDir}/bin/byoh-hostagent-linux-amd64
-kubernetesVersion="v1.22.3"
+kubernetesVersion="v1.23.4"
 
 readArgs $@
 userConfirmation

--- a/hack/getting_started.sh
+++ b/hack/getting_started.sh
@@ -537,7 +537,7 @@ manageClusterConfFile="${HOME}/.kube/management-cluster.conf"
 kubeConfigFile=/tmp/byoh-cluster-kubeconfig
 reposDir=$(dirname $0)/../
 byohBinaryFile=${reposDir}/bin/byoh-hostagent-linux-amd64
-kubernetesVersion="v1.23.4"
+kubernetesVersion="v1.23.5"
 
 readArgs $@
 userConfirmation

--- a/test/e2e/BYOHDockerFile
+++ b/test/e2e/BYOHDockerFile
@@ -5,7 +5,7 @@ ARG TARGETARCH
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         systemd conntrack iptables iproute2 ethtool socat util-linux mount \
-        ebtables kmod libseccomp2 pigz bash ca-certificates \
+        apparmor-utils ebtables kmod libseccomp2 pigz bash ca-certificates \
         rsync nfs-common fuse-overlayfs curl gnupg2 \
         dbus ufw linux-image-$(uname -r) \
     && ln -s "$(which systemd)" /sbin/init

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -79,7 +79,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.22.3"
+  KUBERNETES_VERSION: "v1.23.5"
   ETCD_VERSION_UPGRADE_TO: "3.4.9-0"
   COREDNS_VERSION_UPGRADE_TO: "1.7.0"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
@@ -95,7 +95,7 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.1.3/clusterctl-{OS}-{ARCH}"
-  BUNDLE_LOOKUP_TAG: "v1.22.3"
+  BUNDLE_LOOKUP_TAG: "v1.23.5"
   CONTROL_PLANE_ENDPOINT_IP: ""
 
 intervals:

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -25,7 +25,7 @@ import (
 )
 
 const (
-	kindImage          = "byoh/node:v1.22.3"
+	kindImage          = "byoh/node:e2e"
 	tempKubeconfigPath = "/tmp/mgmt.conf"
 )
 


### PR DESCRIPTION
- updated e2e k8s version to `v1.23.5`
- updated corresponding Dockerfiles
- pushed a new bundle to Harbor
- minor corrections to docs

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #413 #415 

**Additional information**
New OCI image pushed to Harbor. You can check with `docker pull projects.registry.vmware.com/cluster_api_provider_bringyourownhost/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.23.5`
