### PR TITLE
Added OS and K8s version support in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,18 @@ More about development and contributing practices can be found in [`CONTRIBUTING
 
 ------
 
-## Compatibility with Cluster API and Kubernetes Versions
+## Compatibility with Cluster API
 
 - BYOH is currently compatible wth Cluster API v1beta1 (v1.0)
-- BYOH installer support is present and tested only for Kubernetes version `v1.22.3`. You may however use it to provision clusters of a different version by manually installing the Kubernetes components (use the `--skip-installation` flag when starting the agent)
 
+## Supported OS and Kubernetes versions
+| Operating System  | Architecture  | Kubernetes v1.21.* | Kubernetes v1.22.* | Kubernetes v1.23.* |
+| ------------------|---------------| :----------------: | :----------------: | :----------------: |
+| Ubuntu 20.04.*    | amd64         |        ✓           |        ✓           |        ✓           |
+
+**NOTE:**  The '*' in OS means that all Ubuntu 20.04 patches are supported.
+
+**NOTE:**  The '*' in the K8s version means that the K8s minor release is supported but it may happen that a BYOH bundle for a specific patch may not exist in the OCI registry.
 
 ## BYOH in News
 - [TGIK episode on BYOH](https://www.youtube.com/watch?v=Xwm5Ka27-Io&t=2838s)


### PR DESCRIPTION
**What this PR does / why we need it**:
Added OS and K8s version support in README.md

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/issues/478

**Additional information**
Earlier BYOH supported only a single version of Ubuntu and k8s. But now we support multiple versions of these.
[Here](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/blob/main/docs/local_dev.md#supported-os-and-kubernetes) is the list of supported OS and k8s versions. Added the required section in the README.md

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->