### PR TITLE
Add host platform to ByoHost CR info on registration

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -68,6 +68,9 @@ type ByoHostStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=byohosts,scope=Namespaced,shortName=byoh
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="OSName",type="string",JSONPath=`.status.hostinfo.osname`
+//+kubebuilder:printcolumn:name="OSImage",type="string",JSONPath=`.status.hostinfo.osimage`
+//+kubebuilder:printcolumn:name="Arch",type="string",JSONPath=`.status.hostinfo.architecture`
 
 // ByoHost is the Schema for the byohosts API
 type ByoHost struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
@@ -18,7 +18,17 @@ spec:
     singular: byohost
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.hostinfo.osname
+      name: OSName
+      type: string
+    - jsonPath: .status.hostinfo.osimage
+      name: OSImage
+      type: string
+    - jsonPath: .status.hostinfo.architecture
+      name: Arch
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ByoHost is the Schema for the byohosts API


### PR DESCRIPTION
Signed-off-by: Shubham Bajpai <shbajpai@vmware.com>

**What this PR does / why we need it**:

This PR adds the host platform information (arch/os/distribution) to the ByoHost CR when the agent registers the host. Tested the same locally and this is what the CR would look like.

```yaml
$ kubectl get byohosts host1 -oyaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ByoHost
metadata:
  creationTimestamp: "2022-04-25T05:52:54Z"
  generation: 1
  name: host1
  namespace: default
  resourceVersion: "169327"
  uid: 572acde9-2d80-446c-ab7a-260f71e8e8f4
spec: {}
status:
  conditions:
  - lastTransitionTime: "2022-04-25T05:52:55Z"
    reason: WaitingForMachineRefToBeAssigned
    severity: Info
    status: "False"
    type: K8sNodeBootstrapSucceeded
  hostinfo:
    architecture: arm64
    osimage: Ubuntu 20.04.4 LTS
    osname: linux
  network:
  ...
```

This PR also adds additional printers for the Byohost CRD and with those the output would look like this:
```shell
$ kubectl get byohost                                                  
NAME    OSNAME   OSIMAGE              ARCH
host1   linux    Ubuntu 20.04.4 LTS   amd64
host2   linux    Ubuntu 20.04.4 LTS   amd64
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #470 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->