### PR TITLE
Adding use-installer-flag to host agent

### DIFF
--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -23,6 +23,7 @@ var _ = Describe("Help flag for host agent", func() {
 				"--metricsbindaddress string",
 				"--namespace string",
 				"--skip-installation",
+				"--use-installer-controller",
 				"--version",
 				"-v, --v",
 				"--feature-gates mapStringBool",

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -584,7 +584,6 @@ var _ = Describe("Agent", func() {
 
 			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
 			runner.CommandArgs["--use-installer-controller"] = ""
-			fmt.Printf("runner: %v\n", runner)
 
 			byoHostContainer, err = runner.SetupByoDockerHost()
 			Expect(err).NotTo(HaveOccurred())
@@ -610,7 +609,6 @@ var _ = Describe("Agent", func() {
 				_, err := os.Stat(agentLogFile)
 				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					fmt.Printf("data: %v\n", string(data))
 					if err == nil && strings.Contains(string(data), "\"msg\"=\"use-installer-controller flag set, skipping intree installer\"") {
 						return true
 					}

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -507,8 +507,9 @@ var _ = Describe("Agent", func() {
 
 		BeforeEach(func() {
 			ns = builder.Namespace("testns").Build()
-			Expect(k8sClient.Create(context.TODO(), ns)).NotTo(HaveOccurred(), "failed to create test namespace")
 			ctx = context.TODO()
+			Expect(k8sClient.Create(ctx, ns)).NotTo(HaveOccurred(), "failed to create test namespace")
+
 			var err error
 			hostName, err = os.Hostname()
 			Expect(err).NotTo(HaveOccurred())
@@ -560,5 +561,62 @@ var _ = Describe("Agent", func() {
 			}).Should(BeNil())
 		})
 
+	})
+
+	Context("When the host agent is executed with --use-installer-controller flag", func() {
+		var (
+			ns               *corev1.Namespace
+			ctx              context.Context
+			err              error
+			hostName         string
+			runner           *e2e.ByoHostRunner
+			byoHostContainer *container.ContainerCreateCreatedBody
+			output           dockertypes.HijackedResponse
+		)
+
+		BeforeEach(func() {
+			ns = builder.Namespace("testns").Build()
+			ctx = context.TODO()
+			Expect(k8sClient.Create(ctx, ns)).NotTo(HaveOccurred(), "failed to create test namespace")
+
+			hostName, err = os.Hostname()
+			Expect(err).NotTo(HaveOccurred())
+
+			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
+			runner.CommandArgs["--use-installer-controller"] = ""
+			fmt.Printf("runner: %v\n", runner)
+
+			byoHostContainer, err = runner.SetupByoDockerHost()
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
+		})
+
+		It("should not call the intree installer", func() {
+			output, _, err = runner.ExecByoDockerHost(byoHostContainer)
+			Expect(err).NotTo(HaveOccurred())
+			defer output.Close()
+			f := e2e.WriteDockerLog(output, agentLogFile)
+			defer func() {
+				deferredErr := f.Close()
+				if deferredErr != nil {
+					e2e.Showf("error closing file %s: %v", agentLogFile, deferredErr)
+				}
+			}()
+			Eventually(func() (done bool) {
+				_, err := os.Stat(agentLogFile)
+				if err == nil {
+					data, err := os.ReadFile(agentLogFile)
+					fmt.Printf("data: %v\n", string(data))
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"use-installer-controller flag set, skipping intree installer\"") {
+						return true
+					}
+				}
+				return false
+			}, 30).Should(BeTrue())
+		})
 	})
 })

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -271,6 +271,7 @@ func (r *HostReconciler) installK8sComponents(ctx context.Context, byoHost *infr
 	bundleRegistry := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupBaseRegistryAnnotation]
 	k8sVersion := byoHost.GetAnnotations()[infrastructurev1beta1.K8sVersionAnnotation]
 	byohBundleTag := byoHost.GetAnnotations()[infrastructurev1beta1.BundleLookupTagAnnotation]
+
 	err := r.K8sInstaller.Install(bundleRegistry, k8sVersion, byohBundleTag)
 	if err != nil {
 		return err

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -37,12 +37,14 @@ type IK8sInstaller interface {
 
 // HostReconciler encapsulates the data/logic needed to reconcile a ByoHost
 type HostReconciler struct {
-	Client         client.Client
-	CmdRunner      cloudinit.ICmdRunner
-	FileWriter     cloudinit.IFileWriter
-	TemplateParser cloudinit.ITemplateParser
-	Recorder       record.EventRecorder
-	K8sInstaller   IK8sInstaller
+	Client                 client.Client
+	CmdRunner              cloudinit.ICmdRunner
+	FileWriter             cloudinit.IFileWriter
+	TemplateParser         cloudinit.ITemplateParser
+	Recorder               record.EventRecorder
+	K8sInstaller           IK8sInstaller
+	SkipK8sInstallation    bool
+	UseInstallerController bool
 }
 
 const (
@@ -112,8 +114,14 @@ func (r *HostReconciler) reconcileNormal(ctx context.Context, byoHost *infrastru
 			return ctrl.Result{}, err
 		}
 
-		if r.K8sInstaller == nil {
+		if r.SkipK8sInstallation {
 			logger.Info("Skipping installation of k8s components")
+		} else if r.UseInstallerController {
+			if byoHost.Spec.InstallationSecret == nil {
+				logger.Info("K8sInstallationSecret not ready")
+				conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded, infrastructurev1beta1.K8sInstallationSecretUnavailableReason, clusterv1.ConditionSeverityInfo, "")
+				return ctrl.Result{}, nil
+			}
 		} else {
 			err = r.installK8sComponents(ctx, byoHost)
 			if err != nil {
@@ -205,7 +213,7 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 		if err != nil {
 			return err
 		}
-		if r.K8sInstaller == nil {
+		if r.SkipK8sInstallation {
 			logger.Info("Skipping uninstallation of k8s components")
 		} else {
 			err = r.uninstallk8sComponents(ctx, byoHost)

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -233,6 +233,7 @@ runCmd:
 				})
 
 				It("should set K8sNodeBootstrapSucceeded to false with Reason CloudInitExecutionFailedReason if the bootstrap execution fails", func() {
+					hostReconciler.K8sInstaller = fakeInstaller
 					fakeCommandRunner.RunCmdReturns(errors.New("I failed"))
 
 					result, reconcilerErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
@@ -257,6 +258,7 @@ runCmd:
 					// assert events
 					events := eventutils.CollectEvents(recorder.Events)
 					Expect(events).Should(ConsistOf([]string{
+						"Normal k8sComponentInstalled Successfully Installed K8s components",
 						"Warning BootstrapK8sNodeFailed k8s Node Bootstrap failed",
 						// TODO: improve test to remove this event
 						"Warning ResetK8sNodeFailed k8s Node Reset failed",
@@ -264,6 +266,7 @@ runCmd:
 				})
 
 				It("should set K8sNodeBootstrapSucceeded to True if the boostrap execution succeeds", func() {
+					hostReconciler.K8sInstaller = fakeInstaller
 					result, reconcilerErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
 						NamespacedName: byoHostLookupKey,
 					})
@@ -286,6 +289,7 @@ runCmd:
 					// assert events
 					events := eventutils.CollectEvents(recorder.Events)
 					Expect(events).Should(ConsistOf([]string{
+						"Normal k8sComponentInstalled Successfully Installed K8s components",
 						"Normal BootstrapK8sNodeSucceeded k8s Node Bootstraped",
 					}))
 				})
@@ -316,6 +320,7 @@ runCmd:
 				})
 
 				It("should execute bootstrap secret only once ", func() {
+					hostReconciler.K8sInstaller = fakeInstaller
 					_, reconcilerErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
 						NamespacedName: byoHostLookupKey,
 					})
@@ -383,6 +388,7 @@ runCmd:
 			})
 
 			It("should reset the node and set the Reason to K8sNodeAbsentReason", func() {
+				hostReconciler.K8sInstaller = fakeInstaller
 				result, reconcilerErr := hostReconciler.Reconcile(ctx, controllerruntime.Request{
 					NamespacedName: byoHostLookupKey,
 				})

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -45,13 +45,14 @@ var _ = Describe("Byohost Agent Tests", func() {
 		fakeInstaller = &reconcilerfakes.FakeIK8sInstaller{}
 		recorder = record.NewFakeRecorder(32)
 		hostReconciler = &reconciler.HostReconciler{
-			Client:              k8sClient,
-			CmdRunner:           fakeCommandRunner,
-			FileWriter:          fakeFileWriter,
-			TemplateParser:      fakeTemplateParser,
-			Recorder:            recorder,
-			K8sInstaller:        nil,
-			SkipK8sInstallation: false,
+			Client:                 k8sClient,
+			CmdRunner:              fakeCommandRunner,
+			FileWriter:             fakeFileWriter,
+			TemplateParser:         fakeTemplateParser,
+			Recorder:               recorder,
+			K8sInstaller:           nil,
+			SkipK8sInstallation:    false,
+			UseInstallerController: false,
 		}
 	})
 

--- a/apis/infrastructure/v1beta1/condition_consts.go
+++ b/apis/infrastructure/v1beta1/condition_consts.go
@@ -26,6 +26,11 @@ const (
 	// This secret is available on byohost.Spec.BootstrapSecret field
 	BootstrapDataSecretUnavailableReason = "BootstrapDataSecretUnavailable"
 
+	// K8sInstallationSecretUnavailableReason indicates that the installer controller is yet to provide the
+	// secret that contains installation and uninstallation scripts
+	// This secret is available on byohost.Spec.K8sInstallationSecret field
+	K8sInstallationSecretUnavailableReason = "K8sInstallationSecretUnavailable"
+
 	// CleanK8sDirectoriesFailedReason indicates that clean k8s directories failed for some reason, please
 	// delete it manually for reconcile to proceed.
 	// The cleaned directories are /run/kubeadm and /etc/cni/net.d


### PR DESCRIPTION
- this flag indicates we have to use the script provided by the
  installer controller
- added a new Reason for this flag
- refactored skip-installation code path
- added unit and integration tests cases

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #464 
