### PR TITLE
Add host platform to ByoHost CR info on registration

### DIFF
--- a/agent/registration/host_registrar.go
+++ b/agent/registration/host_registrar.go
@@ -74,11 +74,11 @@ func (hr *HostRegistrar) Register(hostName, namespace string, hostLabels map[str
 	}
 
 	// run it at startup or reboot
-	return hr.UpdateNetwork(ctx, byoHost)
+	return hr.UpdateHost(ctx, byoHost)
 }
 
-// UpdateNetwork updates the network interface status for the host
-func (hr *HostRegistrar) UpdateNetwork(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
+// UpdateHost updates the network interface and host platform details status for the host
+func (hr *HostRegistrar) UpdateHost(ctx context.Context, byoHost *infrastructurev1beta1.ByoHost) error {
 	klog.Info("Add Network Info")
 	helper, err := patch.NewHelper(byoHost, hr.K8sClient)
 	if err != nil {
@@ -87,7 +87,7 @@ func (hr *HostRegistrar) UpdateNetwork(ctx context.Context, byoHost *infrastruct
 
 	byoHost.Status.Network = hr.GetNetworkStatus()
 
-	klog.Info("Add Host Info")
+	klog.Info("Attach Host Platform details")
 	if byoHost.Status.HostDetails, err = hr.getHostInfo(); err != nil {
 		return err
 	}

--- a/agent/registration/host_registrar_test.go
+++ b/agent/registration/host_registrar_test.go
@@ -1,0 +1,74 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint: testpackage
+package registration
+
+import (
+	"fmt"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"io/ioutil"
+	"os"
+)
+
+func getMockFile(targetOs string) ([]byte, error) {
+	out := fmt.Sprintf(`NAME="Ubuntu"
+VERSION="20.04.4 LTS (Focal Fossa)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="%s"
+VERSION_ID="20.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=focal
+UBUNTU_CODENAME=focal`, targetOs)
+	return []byte(out), nil
+}
+
+var _ = Describe("Host Registrar Tests", func() {
+	Context("When the OS is detected", func() {
+		It("Should return the operating system for os following /etc/os-release", func() {
+			targetOs := "Ubuntu 20.04.4 LTS"
+			detectedOS, err := getOperatingSystem(func(string) ([]byte, error) { return getMockFile(targetOs) })
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(detectedOS).To(Equal("Ubuntu 20.04.4 LTS"))
+		})
+
+		It("Should return the operating system for os following /usr/lib/os-release", func() {
+			targetOs := "Clear Linux Initramfs"
+			detectedOS, err := getOperatingSystem(func(releaseFile string) ([]byte, error) {
+				if releaseFile == "/etc/os-release" {
+					return nil, os.ErrNotExist
+				}
+				return getMockFile(targetOs)
+			})
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(detectedOS).To(Equal("Clear Linux Initramfs"))
+		})
+
+		It("Should not error with real hostnamectl", func() {
+			_, err := getOperatingSystem(ioutil.ReadFile)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+	})
+
+	Context("When the os-release file is missing", func() {
+		It("Should return error", func() {
+			_, err := getOperatingSystem(func(string) ([]byte, error) {
+				return nil, os.ErrNotExist
+			})
+			Expect(err.Error()).To(Equal("error opening file : file does not exist"))
+		})
+	})
+
+	Context("When the os-release does not contain PRETTY_NAME", func() {
+		It("Should return Unknown as operating system", func() {
+			detectedOS, err := getOperatingSystem(func(string) ([]byte, error) { return []byte("some_file_without_PRETTY_NAME"), nil })
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(detectedOS).To(Equal("Unknown"))
+		})
+	})
+})

--- a/apis/infrastructure/v1beta1/byohost_types.go
+++ b/apis/infrastructure/v1beta1/byohost_types.go
@@ -73,6 +73,9 @@ type ByoHostStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:resource:path=byohosts,scope=Namespaced,shortName=byoh
 //+kubebuilder:subresource:status
+//+kubebuilder:printcolumn:name="OSName",type="string",JSONPath=`.status.hostinfo.osname`
+//+kubebuilder:printcolumn:name="OSImage",type="string",JSONPath=`.status.hostinfo.osimage`
+//+kubebuilder:printcolumn:name="Arch",type="string",JSONPath=`.status.hostinfo.architecture`
 
 // ByoHost is the Schema for the byohosts API
 type ByoHost struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_byohosts.yaml
@@ -18,7 +18,17 @@ spec:
     singular: byohost
   scope: Namespaced
   versions:
-  - name: v1beta1
+  - additionalPrinterColumns:
+    - jsonPath: .status.hostinfo.osname
+      name: OSName
+      type: string
+    - jsonPath: .status.hostinfo.osimage
+      name: OSImage
+      type: string
+    - jsonPath: .status.hostinfo.architecture
+      name: Arch
+      type: string
+    name: v1beta1
     schema:
       openAPIV3Schema:
         description: ByoHost is the Schema for the byohosts API


### PR DESCRIPTION
Signed-off-by: Shubham Bajpai <shbajpai@vmware.com>

**What this PR does / why we need it**:

This PR adds the host platform information (arch/os/distribution) to the ByoHost CR when the agent registers the host. Tested the same locally and this is what the CR would look like.

```yaml
$ kubectl get byohosts host1 -oyaml
apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
kind: ByoHost
metadata:
  creationTimestamp: "2022-04-25T05:52:54Z"
  generation: 1
  name: host1
  namespace: default
  resourceVersion: "169327"
  uid: 572acde9-2d80-446c-ab7a-260f71e8e8f4
spec: {}
status:
  conditions:
  - lastTransitionTime: "2022-04-25T05:52:55Z"
    reason: WaitingForMachineRefToBeAssigned
    severity: Info
    status: "False"
    type: K8sNodeBootstrapSucceeded
  hostinfo:
    architecture: arm64
    osimage: Ubuntu 20.04.4 LTS
    osname: linux
  network:
  ...
```

This PR also adds additional printers for the Byohost CRD and with those the output would look like this:
```shell
$ kubectl get byohost                                                  
NAME    OSNAME   OSIMAGE              ARCH
host1   linux    Ubuntu 20.04.4 LTS   amd64
host2   linux    Ubuntu 20.04.4 LTS   amd64
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #470 

**Additional information**
The function added in this PR fetches information directly from files from the underneath operating system. Hence not sure how to add a test for the same. 

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->