### PR TITLE
Add condition for Installation Secret

### DIFF
--- a/apis/infrastructure/v1beta1/condition_consts.go
+++ b/apis/infrastructure/v1beta1/condition_consts.go
@@ -71,6 +71,10 @@ const (
 
 	// BYOHostsUnavailableReason indicates that no byohosts are available in the capacity pool
 	BYOHostsUnavailableReason = "BYOHostsUnavailable"
+
+	// InstallationSecretNotAvailableReason indicates that the installation secret is not yet
+	// generated for a given BYOMachine
+	InstallationSecretNotAvailableReason = "InstallationSecretNotAvailable"
 )
 
 // Reasons common to all Byo Resources

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -259,6 +259,7 @@ func (r *ByoMachineReconciler) reconcileNormal(ctx context.Context, machineScope
 		if res, err := r.attachByoHost(ctx, machineScope); err != nil {
 			return res, err
 		}
+		conditions.MarkFalse(machineScope.ByoMachine, infrav1.BYOHostReady, infrav1.InstallationSecretNotAvailableReason, clusterv1.ConditionSeverityInfo, "")
 		r.Recorder.Eventf(machineScope.ByoHost, corev1.EventTypeNormal, "ByoHostAttachSucceeded", "Attached to ByoMachine %s", machineScope.ByoMachine.Name)
 		r.Recorder.Eventf(machineScope.ByoMachine, corev1.EventTypeNormal, "ByoHostAttachSucceeded", "Attached ByoHost %s", machineScope.ByoHost.Name)
 	}


### PR DESCRIPTION
Signed-off-by: Shubham <shbajpai@vmware.com>

**What this PR does / why we need it**:

This PR adds a condition reason for the BYOMachine for installation secret. This condition will be picked up by the K8sInstaller controller and an installation secret will be created for the given BYOMachine. Ref : https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/blob/main/docs/diagrams/installer-flow.png

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->