### PR TITLE
Add installer contract to ByoMachine controller

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -204,3 +204,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - '*'
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch

--- a/controllers/infrastructure/suite_test.go
+++ b/controllers/infrastructure/suite_test.go
@@ -39,28 +39,29 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	testEnv                       *envtest.Environment
-	clientFake                    client.Client
-	clientSetFake                 = fakeclientset.NewSimpleClientset()
-	reconciler                    *controllers.ByoMachineReconciler
-	byoClusterReconciler          *controllers.ByoClusterReconciler
-	byoAdmissionReconciler        *controllers.ByoAdmissionReconciler
-	k8sInstallerConfigReconciler  *controllers.K8sInstallerConfigReconciler
-	recorder                      *record.FakeRecorder
-	byoCluster                    *infrastructurev1beta1.ByoCluster
-	capiCluster                   *clusterv1.Cluster
-	defaultClusterName            = "my-cluster"
-	defaultNodeName               = "my-host"
-	defaultByoHostName            = "my-host"
-	defaultMachineName            = "my-machine"
-	defaultByoMachineName         = "my-byomachine"
-	defaultK8sInstallerConfigName = "my-k8sinstallerconfig"
-	defaultNamespace              = "default"
-	fakeBootstrapSecret           = "fakeBootstrapSecret"
-	k8sManager                    ctrl.Manager
-	cfg                           *rest.Config
-	ctx                           context.Context
-	cancel                        context.CancelFunc
+	testEnv                               *envtest.Environment
+	clientFake                            client.Client
+	clientSetFake                         = fakeclientset.NewSimpleClientset()
+	reconciler                            *controllers.ByoMachineReconciler
+	byoClusterReconciler                  *controllers.ByoClusterReconciler
+	byoAdmissionReconciler                *controllers.ByoAdmissionReconciler
+	k8sInstallerConfigReconciler          *controllers.K8sInstallerConfigReconciler
+	recorder                              *record.FakeRecorder
+	byoCluster                            *infrastructurev1beta1.ByoCluster
+	capiCluster                           *clusterv1.Cluster
+	defaultClusterName                    = "my-cluster"
+	defaultNodeName                       = "my-host"
+	defaultByoHostName                    = "my-host"
+	defaultMachineName                    = "my-machine"
+	defaultByoMachineName                 = "my-byomachine"
+	defaultK8sInstallerConfigName         = "my-k8sinstallerconfig"
+	defaultK8sInstallerConfigTemplateName = "my-installer-template"
+	defaultNamespace                      = "default"
+	fakeBootstrapSecret                   = "fakeBootstrapSecret"
+	k8sManager                            ctrl.Manager
+	cfg                                   *rest.Config
+	ctx                                   context.Context
+	cancel                                context.CancelFunc
 )
 
 func TestAPIs(t *testing.T) {

--- a/test/builder/builders.go
+++ b/test/builder/builders.go
@@ -559,17 +559,17 @@ func (b *K8sInstallerConfigBuilder) Build() *infrastructurev1beta1.K8sInstallerC
 
 // K8sInstallerConfigTemplateBuilder holds the variables and objects required to build an infrastructurev1beta1.K8sInstallerConfigTemplate
 type K8sInstallerConfigTemplateBuilder struct {
-	namespace  string
-	name       string
-	bundleType string
-	bundleRepo string
+	namespace     string
+	generatedName string
+	bundleType    string
+	bundleRepo    string
 }
 
-// K8sInstallerConfigTemplate returns a K8sInstallerConfigTemplateBuilder with the given name and namespace
+// K8sInstallerConfigTemplate returns a K8sInstallerConfigTemplateBuilder with the given generated name and namespace
 func K8sInstallerConfigTemplate(namespace, name string) *K8sInstallerConfigTemplateBuilder {
 	return &K8sInstallerConfigTemplateBuilder{
-		namespace: namespace,
-		name:      name,
+		namespace:     namespace,
+		generatedName: name,
 	}
 }
 
@@ -593,7 +593,7 @@ func (b *K8sInstallerConfigTemplateBuilder) Build() *infrastructurev1beta1.K8sIn
 			APIVersion: infrastructurev1beta1.GroupVersion.String(),
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: b.name,
+			GenerateName: b.generatedName,
 			Namespace:    b.namespace,
 		},
 		Spec: infrastructurev1beta1.K8sInstallerConfigTemplateSpec{},


### PR DESCRIPTION
**What this PR does / why we need it**:

This Pr adds the following logic for ByoMachine controller:
 - creates a InstallerConfig for each ByoMachine if it does not exists already using the installerRef template on the machine
 - patches the host platform details to ByoMachine once a ByoHost is attached to it
 - once the InstallerConfig is marked with status Ready it patches the Secret reference on the InstallerConfig to ByoHost

Ref: https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/blob/main/docs/diagrams/installer-flow.png

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->