### PR TITLE
Added ClusterRoleBinding for host agent user

### DIFF
--- a/config/rbac/byohost_editor_clusterrolebinding.yaml
+++ b/config/rbac/byohost_editor_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: byohost-editor-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: byohost-editor-role
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
+  name: byoh:hosts

--- a/config/rbac/byohost_editor_role.yaml
+++ b/config/rbac/byohost_editor_role.yaml
@@ -22,3 +22,5 @@ rules:
   - byohosts/status
   verbs:
   - get
+  - patch
+  - update


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR introduces a `ClusterRoleBinding` for the `byoh:hosts` group as subject, so that the new certificate user(host agent) can do CRUD operation on `ByoHost` CRD.

**Which issue(s) this PR fixes** :
Fixes #545 

**Additional information**

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->