### PR TITLE
fixed: Byoh hostinfo.architecture is not matching with the supported bundle name

### DIFF
--- a/common/installer/installer.go
+++ b/common/installer/installer.go
@@ -17,10 +17,20 @@ type K8sInstaller interface {
 	Uninstall() string
 }
 
+// archOldNameMap keeps the mapping of architecture new name to old name mapping
+var archOldNameMap = map[string]string{
+	"amd64": "x86-64",
+}
+
 // NewInstaller will return a new installer
 func NewInstaller(ctx context.Context, osDist, arch, k8sVersion string, downloader BundleDownloader) (K8sInstaller, error) {
+	bundleArchName := arch
+	// replacing the arch name to old name to match with the bundle name
+	if _, exists := archOldNameMap[arch]; exists {
+		bundleArchName = archOldNameMap[arch]
+	}
 	// normalizing os image name and adding arch
-	osArch := strings.ReplaceAll(osDist, " ", "_") + "_" + arch
+	osArch := strings.ReplaceAll(osDist, " ", "_") + "_" + bundleArchName
 
 	reg := installer.GetSupportedRegistry(nil)
 	if len(reg.ListK8s(osArch)) == 0 {

--- a/common/installer/internal/algo/ubuntu20_4k8s.go
+++ b/common/installer/internal/algo/ubuntu20_4k8s.go
@@ -83,17 +83,18 @@ if ! command -v imgpkg >>/dev/null; then
 	chmod +x /usr/local/bin/imgpkg
 fi
 
-if [ ! -d $BUNDLE_PATH ]; then
-	echo "downloading bundle"
-	imgpkg pull -r -i $BUNDLE_ADDR -o $BUNDLE_PATH
-fi
+echo "downloading bundle"
+mkdir -p $BUNDLE_PATH
+imgpkg pull -r -i $BUNDLE_ADDR -o $BUNDLE_PATH
 
 
 ## disable swap
 swapoff -a && sed -ri '/\sswap\s/s/^#?/#/' /etc/fstab
 
 ## disable firewall
-ufw disable
+if command -v ufw >>/dev/null; then
+	ufw disable
+fi
 
 ## load kernal modules
 modprobe overlay && modprobe br_netfilter
@@ -123,7 +124,9 @@ BUNDLE_PATH=$BUNDLE_DOWNLOAD_PATH/$BUNDLE_ADDR
 swapon -a && sed -ri '/\sswap\s/s/^#?//' /etc/fstab
 
 ## enable firewall
-ufw enable
+if command -v ufw >>/dev/null; then
+	ufw enable
+fi
 
 ## remove kernal modules
 modprobe -r overlay && modprobe -r br_netfilter

--- a/controllers/infrastructure/k8sinstallerconfig_controller_test.go
+++ b/controllers/infrastructure/k8sinstallerconfig_controller_test.go
@@ -189,9 +189,9 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 			ph, err := patch.NewHelper(byoMachine, k8sClientUncached)
 			Expect(err).ShouldNot(HaveOccurred())
 			byoMachine.Status.HostInfo = infrav1.HostInfo{
-				Architecture: "x86-64",
+				Architecture: "amd64",
 				OSName:       "linux",
-				OSImage:      "Ubuntu 20.04.1",
+				OSImage:      "Ubuntu 20.04.1 LTS",
 			}
 			conditions.Set(byoMachine, &clusterv1.Condition{
 				Type:   infrav1.BYOHostReady,
@@ -199,7 +199,7 @@ var _ = Describe("Controllers/K8sInstallerConfigController", func() {
 			})
 			Expect(ph.Patch(ctx, byoMachine, patch.WithStatusObservedGeneration{})).Should(Succeed())
 			WaitForObjectToBeUpdatedInCache(byoMachine, func(object client.Object) bool {
-				return object.(*infrav1.ByoMachine).Status.HostInfo.Architecture == "x86-64"
+				return object.(*infrav1.ByoMachine).Status.HostInfo.Architecture == "amd64"
 			})
 		})
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Byoh hostinfo.architecture is not matching with the supported bundle name.
**Solution:**
in installer, replaced the new architecture name with the old one to
match with the bundle name.  

**Extra changes**
- fixed download package script command as output directory need to be created before pulling the bundle.
- Executed firewall enable/disable command only if ufw command exists.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #547 
