### PR TITLE
Agent changes to support kubeconfig bootstrap flow

### DIFF
--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -205,7 +205,7 @@ var _ = Describe("Agent", func() {
 			}).Should(Equal(map[string]string{"site": "apac"}))
 		})
 
-		It("should skip bootstrap flow in default mode", func() {
+		It("should skip bootstrap kubeconfig flow in default mode", func() {
 			defer output.Close()
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
@@ -568,7 +568,7 @@ var _ = Describe("Agent", func() {
 			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
 		})
 
-		It("should enable the bootstrap flow", func() {
+		It("should enable the bootstrap kubeconfig flow", func() {
 			defer output.Close()
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
@@ -832,21 +832,13 @@ var _ = Describe("Agent Unit Tests", func() {
 			Expect(os.Remove(bootstrapKubeConf.Name())).ShouldNot(HaveOccurred())
 		})
 		It("should return if bootstrap kubeconfig is not valid", func() {
-			testbootstrapKubeconfigInvalid := []byte(`
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    certificate-authority: ca.crt
-    server: https://cluster-a.com
-  name: cluster-a
-`)
+			testbootstrapKubeconfigInvalid := []byte(`abc`)
 
 			_, err = bootstrapKubeConf.Write(testbootstrapKubeconfigInvalid)
 			Expect(err).NotTo(HaveOccurred())
 			err = handleBootstrapFlow(klogr.New(), "test-host")
 			Expect(err).Should(HaveOccurred())
-			Expect(err.Error()).Should(ContainSubstring("client config load failed: invalid configuration"))
+			Expect(err.Error()).Should(ContainSubstring("client config load failed"))
 		})
 		It("should return if hostName is not valid", func() {
 			testbootstrapKubeconfigValid := []byte(`

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"net"
 	"os"
 	"os/exec"
@@ -30,6 +31,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/klog/v2/klogr"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	"sigs.k8s.io/cluster-api/util/patch"
 )
@@ -203,7 +205,7 @@ var _ = Describe("Agent", func() {
 			}).Should(Equal(map[string]string{"site": "apac"}))
 		})
 
-		It("should skip CSR creation in default mode", func() {
+		It("should skip bootstrap flow in default mode", func() {
 			defer output.Close()
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
@@ -217,7 +219,7 @@ var _ = Describe("Agent", func() {
 				_, err := os.Stat(agentLogFile)
 				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					if err == nil && !strings.Contains(string(data), "creating host csr") {
+					if err == nil && !strings.Contains(string(data), "initiated bootstrap kubeconfig flow") {
 						return true
 					}
 				}
@@ -521,7 +523,7 @@ var _ = Describe("Agent", func() {
 		})
 	})
 
-	Context("When the host agent is executed with SecureAccess feature flag", func() {
+	Context("When the host agent is executed with --bootstrap-kubeconfig", func() {
 
 		var (
 			ns               *corev1.Namespace
@@ -542,7 +544,6 @@ var _ = Describe("Agent", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			runner = setupTestInfra(ctx, hostName, getKubeConfig().Name(), ns)
-			runner.CommandArgs["--feature-gates"] = "SecureAccess=true"
 			runner.CommandArgs["--bootstrap-kubeconfig"] = "/mgmt.conf"
 			byoHostContainer, err = runner.SetupByoDockerHost()
 			Expect(err).NotTo(HaveOccurred())
@@ -567,7 +568,7 @@ var _ = Describe("Agent", func() {
 			cleanup(runner.Context, byoHostContainer, ns, agentLogFile)
 		})
 
-		It("should enable the SecureAccess feature gate", func() {
+		It("should enable the bootstrap flow", func() {
 			defer output.Close()
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
@@ -580,7 +581,7 @@ var _ = Describe("Agent", func() {
 				_, err := os.Stat(agentLogFile)
 				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					if err == nil && strings.Contains(string(data), "\"msg\"=\"secure access enabled, waiting for host to be registered by ByoAdmission Controller\"") {
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"initiated bootstrap kubeconfig flow\"") {
 						return true
 					}
 				}
@@ -598,7 +599,7 @@ var _ = Describe("Agent", func() {
 				return createdByoHost
 			}).Should(BeNil())
 		})
-		It("should create BYOHost CSR in the management cluster", func() {
+		It("should create ByoHost CSR in the management cluster", func() {
 			defer output.Close()
 			f := e2e.WriteDockerLog(output, agentLogFile)
 			defer func() {
@@ -673,7 +674,7 @@ var _ = Describe("Agent", func() {
 				_, err := os.Stat(agentLogFile)
 				if err == nil {
 					data, err := os.ReadFile(agentLogFile)
-					if err == nil && strings.Contains(string(data), "\"msg\"=\"Waiting for client certificate to be issued\"") {
+					if err == nil && strings.Contains(string(data), "\"msg\"=\"waiting for client certificate to be issued\"") {
 						return true
 					}
 				}
@@ -812,6 +813,67 @@ kovW9X7Ook/tTW0HyX6D6HRciA==
 				}
 				return false
 			}, 30).Should(BeTrue())
+		})
+	})
+})
+
+var _ = Describe("Agent Unit Tests", func() {
+	Context("When the handleBootstrap func is called", func() {
+		var (
+			bootstrapKubeConf *os.File
+			err               error
+		)
+		BeforeEach(func() {
+			bootstrapKubeConf, err = ioutil.TempFile("", "bootstrap-kubeconfig")
+			Expect(err).NotTo(HaveOccurred())
+			bootstrapKubeConfig = bootstrapKubeConf.Name()
+		})
+		AfterEach(func() {
+			Expect(os.Remove(bootstrapKubeConf.Name())).ShouldNot(HaveOccurred())
+		})
+		It("should return if bootstrap kubeconfig is not valid", func() {
+			testbootstrapKubeconfigInvalid := []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: ca.crt
+    server: https://cluster-a.com
+  name: cluster-a
+`)
+
+			_, err = bootstrapKubeConf.Write(testbootstrapKubeconfigInvalid)
+			Expect(err).NotTo(HaveOccurred())
+			err = handleBootstrapFlow(klogr.New(), "test-host")
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("client config load failed: invalid configuration"))
+		})
+		It("should return if hostName is not valid", func() {
+			testbootstrapKubeconfigValid := []byte(`
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRFNU1URXlNREF3TkRrME1sb1hEVEk1TVRFeE56QXdORGswTWxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTXFRCmN0RUN6QTh5RlN1Vll1cE9VWWdyVG1mUWVLZS85QmFEV2FnYXE3b3c5K0kySXZzZldGdmxyRDhRUXI4c2VhNnEKeGpxN1RWNjdWYjRSeEJhb1lEQSt5STV2SWN1aldVeFVMdW42NGx1M1E2aUMxc2oyVW5tVXBJZGdhelJYWEVrWgp2eEE2RWJBbm94QTArbEJPbjFDWldsMjNJUTRzNzBvMmhaN3dJcC92ZXZCODhSUlJqcXR2Z2M1ZWxzanNibURGCkxTN0wxWnV5ZThjNmdTOTNiUitWalZtU0lmcjFJRXEwNzQ4dElJeVhqQVZDV1BWQ3Z1UDQxTWxmUGMvSlZwWkQKdUQyK3BPNlpZUkVjZEFuT2YyZUQ0L2VMT01La280TDFkU0Z5OUpLTTVQTG5PQzBaazBBWU9kMXZTOERUQWZ4agpYUEVJWThPQllGaGxzeGY0VEU4Q0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFIL09ZcTh6eWwxK3pTVG11b3czeUkvMTVQTDEKZGw4aEI3SUtuWk5XbUMvTFRkbS8rbm9oM1NiMUlkUnY2SGtLZy9HVW4wVU11UlVuZ0xoanUzRU80b3pKUFFjWApxdWF4emdtVEtOV0o2RXJEdlJ2V2hHWDBaY2JkQmZaditkb3d5UnF6ZDVubEo0OWhDK05ydEZGUXE2UDA1QlluCjdTZW1ndXFlWG1Yd0lqMlNhKzFEZVI2bFJtOW84c2hBWWpueVRoVUZxYU1uMThrSTNTQU5KNXZrLzNERnJQRU8KQ0tDOUV6Rmt1Mmt1eGcyZE0xMlBiUkdaUTJvMEs2SEVaZ3JySUtUUE95M29jYjhyOU0wYVNGaGpPVi9OcUdBNApTYXVwWFNXNlhmdklpL1VIb0liVTNwTmNzblVKR25RZlF2aXA5NVhLay9ncWNVcittNTB2eGd1bXh0QT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
+    server: https://cluster-a.com
+  name: cluster-a
+contexts:
+- context:
+    cluster: cluster-a
+    namespace: ns-a
+    user: user-a
+  name: context-a
+current-context: context-a
+users:
+- name: user-a
+  user:
+    token: mytoken-a
+`)
+			_, err = bootstrapKubeConf.Write(testbootstrapKubeconfigValid)
+			Expect(err).NotTo(HaveOccurred())
+			err = handleBootstrapFlow(klogr.New(), "")
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("kubeconfig generation failed: hostname is not valid"))
 		})
 	})
 })

--- a/agent/registration/csr_test.go
+++ b/agent/registration/csr_test.go
@@ -10,32 +10,26 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/agent/registration"
 	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/test/builder"
 	certv1 "k8s.io/api/certificates/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/klogr"
 )
 
 var _ = Describe("CSR Registration", func() {
 	var (
 		ctx      = context.TODO()
 		hostName = "test-host"
+		fileDir  string
 	)
 	Context("When bootstrap kubeconfig is provided", func() {
-
-		AfterEach(func() {
-			csrList, err := clientSetFake.CertificatesV1().CertificateSigningRequests().List(ctx, v1.ListOptions{})
-			Expect(err).ShouldNot(HaveOccurred())
-			for _, csr := range csrList.Items {
-				err = clientSetFake.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, v1.DeleteOptions{})
-				Expect(err).ShouldNot(HaveOccurred())
-			}
-		})
-		fileDir, err := ioutil.TempDir("", "bootstrap")
-		Expect(err).ShouldNot(HaveOccurred())
 		testDatabootstrapValid := []byte(`
 apiVersion: v1
 kind: Config
@@ -76,9 +70,42 @@ users:
   user:
     token: mytoken-a
 `)
+		var testCert = `
+-----BEGIN CERTIFICATE-----
+MIIBvzCCAWWgAwIBAgIRAMd7Mz3fPrLm1aFUn02lLHowCgYIKoZIzj0EAwIwIzEh
+MB8GA1UEAwwYazNzLWNsaWVudC1jYUAxNjE2NDMxOTU2MB4XDTIxMDQxOTIxNTMz
+MFoXDTIyMDQxOTIxNTMzMFowMjEVMBMGA1UEChMMc3lzdGVtOm5vZGVzMRkwFwYD
+VQQDExBzeXN0ZW06bm9kZTp0ZXN0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE
+Xd9aZm6nftepZpUwof9RSUZqZDgu7dplIiDt8nnhO5Bquy2jn7/AVx20xb0Xz0d2
+XLn3nn5M+lR2p3NlZmqWHaNrMGkwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoG
+CCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwHwYDVR0jBBgwFoAU/fZa5enijRDB25DF
+NT1/vPUy/hMwEwYDVR0RBAwwCoIIRE5TOnRlc3QwCgYIKoZIzj0EAwIDSAAwRQIg
+b3JL5+Q3zgwFrciwfdgtrKv8MudlA0nu6EDQO7eaJbwCIQDegFyC4tjGPp/5JKqQ
+kovW9X7Ook/tTW0HyX6D6HRciA==
+-----END CERTIFICATE-----
+						`
+		BeforeEach(func() {
+			csrList, err := k8sClientSet.CertificatesV1().CertificateSigningRequests().List(ctx, metav1.ListOptions{})
+			Expect(err).ShouldNot(HaveOccurred())
+			for _, csr := range csrList.Items {
+				err = k8sClientSet.CertificatesV1().CertificateSigningRequests().Delete(ctx, csr.Name, metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+			registration.ConfigPath = "/tmp/config"
+			fileDir, err = ioutil.TempDir("", "bootstrap")
+			Expect(err).ShouldNot(HaveOccurred())
+
+		})
+
+		AfterEach(func() {
+			err := os.RemoveAll(fileDir)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
 		It("should return error if hostname is invalid", func() {
-			CSRRegistrar := registration.ByohCSR{BootstrapClient: clientSetFake}
-			_, _, err := CSRRegistrar.RequestBYOHClientCert("")
+			CSRRegistrar, err := registration.NewByohCSR(cfg, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
+			_, _, err = CSRRegistrar.RequestBYOHClientCert("")
 			Expect(err).To(MatchError("hostname is not valid"))
 		})
 		It("should return client config if bootstrap kubeconfig is valid", func() {
@@ -101,10 +128,11 @@ users:
 			Expect(restConfig).To(BeNil())
 		})
 		It("should create csr if bootstrap kubeconfig is valid", func() {
-			CSRRegistrar := registration.ByohCSR{BootstrapClient: clientSetFake}
-			_, _, err := CSRRegistrar.RequestBYOHClientCert(hostName)
+			CSRRegistrar, err := registration.NewByohCSR(cfg, logr.Discard())
+			Expect(err).ShouldNot(HaveOccurred())
+			_, _, err = CSRRegistrar.RequestBYOHClientCert(hostName)
 			Expect(err).NotTo(HaveOccurred())
-			ByohCSR, err := clientSetFake.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), v1.GetOptions{})
+			ByohCSR, err := k8sClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), metav1.GetOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
 			// Validate k8s CSR resource
 			Expect(ByohCSR.Spec.SignerName).Should(Equal(certv1.KubeAPIServerClientSignerName))
@@ -120,36 +148,94 @@ users:
 
 			Expect(os.Remove(registration.TmpPrivateKey)).ShouldNot(HaveOccurred())
 		})
-		It("should write kubeconfig if bootstrap kubeconfig is valid", func() {
-			fileboot, err := ioutil.TempFile(fileDir, "boostrapkubeconfig")
-			Expect(err).ShouldNot(HaveOccurred())
-			filekubeconfig, err := ioutil.TempFile(fileDir, "kubeconfig")
-			Expect(err).ShouldNot(HaveOccurred())
-			err = os.WriteFile(fileboot.Name(), testDatabootstrapValid, os.FileMode(0755))
-			Expect(err).ShouldNot(HaveOccurred())
-			restConfig, err := registration.LoadRESTClientConfig(fileboot.Name())
-			Expect(err).ShouldNot(HaveOccurred())
-			err = registration.WriteKubeconfigFromBootstrapping(restConfig, filekubeconfig.Name(), "cert-data", "key-data")
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(filekubeconfig.Name()).To(BeARegularFile())
-			content, err := os.ReadFile(filekubeconfig.Name())
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(content).ShouldNot(BeEmpty())
-		})
 		It("should fail creating CSR if the private key got changed", func() {
 			byohCSR, err := builder.CertificateSigningRequest(
 				fmt.Sprintf(registration.ByohCSRNameFormat, hostName),
 				fmt.Sprintf(registration.ByohCSRCNFormat, hostName),
 				"byoh:hosts", 2048).Build()
 			Expect(err).NotTo(HaveOccurred())
-			_, err = clientSetFake.CertificatesV1().CertificateSigningRequests().Create(ctx, byohCSR, v1.CreateOptions{})
+			_, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().Create(ctx, byohCSR, metav1.CreateOptions{})
 			Expect(err).ShouldNot(HaveOccurred())
-			CSRRegistrar := registration.ByohCSR{BootstrapClient: clientSetFake}
+			CSRRegistrar, err := registration.NewByohCSR(cfg, klogr.New())
+			Expect(err).ShouldNot(HaveOccurred())
 			_, _, err = CSRRegistrar.RequestBYOHClientCert(hostName)
 			Expect(err).Should(HaveOccurred())
 			Expect(err.Error()).Should(ContainSubstring("retrieved csr is not compatible"))
 
 			Expect(os.Remove(registration.TmpPrivateKey)).ShouldNot(HaveOccurred())
+		})
+		It("should timeout if the CSR is not approved", func() {
+			registration.CSRApprovalTimeout = time.Second * 5
+			CSRRegistrar, err := registration.NewByohCSR(cfg, klogr.New())
+			Expect(err).ShouldNot(HaveOccurred())
+			err = CSRRegistrar.BootstrapKubeconfig(hostName)
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("timed out waiting for the condition"))
+			Expect(os.Remove(registration.TmpPrivateKey)).ShouldNot(HaveOccurred())
+		})
+		It("should return error if not able to write kubeconfig", func() {
+			// Simulate ByoAdmission Controller
+			go func() {
+				for {
+					time.Sleep(time.Millisecond * 100)
+					byohCSR, err := k8sClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), metav1.GetOptions{})
+					if err != nil {
+						continue
+					}
+					byohCSR.Status.Conditions = append(byohCSR.Status.Conditions, certv1.CertificateSigningRequestCondition{
+						Type:    certv1.CertificateApproved,
+						Reason:  "approved",
+						Message: "approved",
+						Status:  corev1.ConditionTrue,
+					})
+					_, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), byohCSR, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					byohCSR, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), metav1.GetOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					byohCSR.Status.Certificate = []byte(testCert)
+					_, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, byohCSR, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					return
+				}
+			}()
+			registration.ConfigPath = "/non-existent-mount/config"
+			CSRRegistrar, err := registration.NewByohCSR(cfg, klogr.New())
+			Expect(err).ShouldNot(HaveOccurred())
+			err = CSRRegistrar.BootstrapKubeconfig(hostName)
+			Expect(err).Should(HaveOccurred())
+			Expect(err).To(MatchError("mkdir /non-existent-mount: permission denied"))
+			Expect(os.Remove(registration.TmpPrivateKey)).ShouldNot(HaveOccurred())
+		})
+		It("should create kubeconfig if csr is approved", func() {
+			// Simulate ByoAdmission Controller
+			go func() {
+				for {
+					time.Sleep(time.Millisecond * 100)
+					byohCSR, err := k8sClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), metav1.GetOptions{})
+					if err != nil {
+						continue
+					}
+					byohCSR.Status.Conditions = append(byohCSR.Status.Conditions, certv1.CertificateSigningRequestCondition{
+						Type:    certv1.CertificateApproved,
+						Reason:  "approved",
+						Message: "approved",
+						Status:  corev1.ConditionTrue,
+					})
+					_, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), byohCSR, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					byohCSR, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().Get(ctx, fmt.Sprintf(registration.ByohCSRNameFormat, hostName), metav1.GetOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					byohCSR.Status.Certificate = []byte(testCert)
+					_, err = k8sClientSet.CertificatesV1().CertificateSigningRequests().UpdateStatus(ctx, byohCSR, metav1.UpdateOptions{})
+					Expect(err).ShouldNot(HaveOccurred())
+					return
+				}
+			}()
+			CSRRegistrar, err := registration.NewByohCSR(cfg, klogr.New())
+			Expect(err).ShouldNot(HaveOccurred())
+			err = CSRRegistrar.BootstrapKubeconfig(hostName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(registration.ConfigPath).To(BeARegularFile())
 		})
 	})
 })

--- a/agent/registration/registration_suite_test.go
+++ b/agent/registration/registration_suite_test.go
@@ -13,7 +13,7 @@ import (
 	certv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	fakeclientset "k8s.io/client-go/kubernetes/fake"
+	clientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -25,10 +25,10 @@ func TestRegistration(t *testing.T) {
 }
 
 var (
-	cfg           *rest.Config
-	k8sClient     client.Client
-	clientSetFake = fakeclientset.NewSimpleClientset()
-	testEnv       *envtest.Environment
+	cfg          *rest.Config
+	k8sClient    client.Client
+	k8sClientSet *clientset.Clientset
+	testEnv      *envtest.Environment
 )
 
 var _ = BeforeSuite(func() {
@@ -57,6 +57,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 	Expect(k8sClient).ToNot(BeNil())
 
+	k8sClientSet = clientset.NewForConfigOrDie(cfg)
+	Expect(k8sClientSet).ToNot(BeNil())
 })
 
 var _ = AfterSuite(func() {

--- a/feature/feature.go
+++ b/feature/feature.go
@@ -8,10 +8,6 @@ import (
 	"k8s.io/component-base/featuregate"
 )
 
-const (
-	SecureAccess featuregate.Feature = "SecureAccess"
-)
-
 var (
 	MutableGates featuregate.MutableFeatureGate = featuregate.NewFeatureGate()
 	Gates        featuregate.FeatureGate        = MutableGates
@@ -23,6 +19,4 @@ func init() {
 
 // defaultClusterAPIBYOHFeatureGates consists of all known cluster-api-byoh feature keys.
 // To add a new feature, define a key for it above and add it here.
-var defaultClusterAPIBYOHFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	SecureAccess: {Default: false, PreRelease: featuregate.Alpha},
-}
+var defaultClusterAPIBYOHFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{}


### PR DESCRIPTION
**What this PR does / why we need it**:
With this PR, `Host-Agent` will supports both the flags `--kubeconfig` and `--bootstrap-kubeconfig`. The feature flag `SecureAccess` is removed and replaced by `--bootstrap-kubeconfig`.

Even with `--kubeconfig` flag, The config will be looked at first in ` ~/.byoh/config` (static path as of now) to support restart workflow and then as per the default precedence rules for `Controller-Runtime` client config discovery. This will help enable the easier deprecation of `--kubeconfig` flag as well.

Unit Test case for `agent/main.go` are added as well.

**Which issue(s) this PR fixes**:
Fixes #560 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->