### PR TITLE
Fixed bugs in agent bootstrap kubeconfig flow

### DIFF
--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -734,7 +734,7 @@ kovW9X7Ook/tTW0HyX6D6HRciA==
 				AttachStdin:  false,
 				AttachStdout: true,
 				AttachStderr: true,
-				Cmd:          []string{"cat", "~/.byoh/config"},
+				Cmd:          []string{"cat", "/root/.byoh/config"},
 			})
 			Expect(err).ShouldNot(HaveOccurred())
 			result, err := cli.ContainerExecAttach(ctx, response.ID, dockertypes.ExecStartCheck{})
@@ -751,7 +751,7 @@ kovW9X7Ook/tTW0HyX6D6HRciA==
 				_, err := os.Stat(execLogFile)
 				if err == nil {
 					data, err := os.ReadFile(execLogFile)
-					if err == nil && strings.Contains(string(data), "name: default-cluster") {
+					if err == nil && strings.Contains(string(data), "name: default-cluster") && strings.Contains(string(data), "client-certificate-data:") {
 						return true
 					}
 				}

--- a/agent/main.go
+++ b/agent/main.go
@@ -170,7 +170,7 @@ func main() {
 	}
 	// Handle kubeconfig flag
 	// first look in the byoh path for the kubeconfig
-	config, err := registration.LoadRESTClientConfig(registration.ConfigPath)
+	config, err := registration.LoadRESTClientConfig(registration.GetBYOHConfigPath())
 	if err != nil {
 		logger.Error(err, "client config load failed")
 		// get the passed kubeconfig

--- a/agent/registration/csr_internal_test.go
+++ b/agent/registration/csr_internal_test.go
@@ -61,7 +61,7 @@ users:
 			Expect(err).ShouldNot(HaveOccurred())
 			restConfig, err := LoadRESTClientConfig(fileboot.Name())
 			Expect(err).ShouldNot(HaveOccurred())
-			err = writeKubeconfigFromBootstrapping(restConfig, filekubeconfig.Name(), "cert-data", "key-data")
+			err = writeKubeconfigFromBootstrapping(restConfig, filekubeconfig.Name(), []byte("cert-data"), []byte("key-data"))
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(filekubeconfig.Name()).To(BeARegularFile())
 			content, err := os.ReadFile(filekubeconfig.Name())

--- a/config/rbac/byoh_csr_creator_clusterrole.yaml
+++ b/config/rbac/byoh_csr_creator_clusterrole.yaml
@@ -12,3 +12,4 @@ rules:
   - create
   - get
   - watch
+  - list


### PR DESCRIPTION
- fixed the user home dir substitution for the config file
- added list permission for `byoh-csr-creator-clusterrole`
- added the cert/key under appropriate keys in kubeconfig

**What this PR does / why we need it**:
Few issues as highlighted above were discovered while manually testing the `host-agent` with the new bootstrap flow.