### PR TITLE
Add e2e test for installer flow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -27,3 +27,8 @@ jobs:
 
     - name: Run PR-Blocking e2e tests
       run: yes | GINKGO_FOCUS="\[PR-Blocking\]" make test-e2e
+
+    - name: Run Installer e2e tests
+      run: |
+        sed -i 's/e2e\/cluster-template.yaml/e2e\/installer\/cluster-template.yaml/' test/e2e/config/provider.yaml
+        yes | GINKGO_FOCUS="\[Installer\]" make test-e2e

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,7 @@ cluster-templates: kustomize cluster-templates-v1beta1
 
 cluster-templates-e2e: kustomize
 	$(KUSTOMIZE) build $(BYOH_TEMPLATES)/v1beta1/templates/e2e --load-restrictor LoadRestrictionsNone > $(BYOH_TEMPLATES)/v1beta1/templates/e2e/cluster-template.yaml
+	$(KUSTOMIZE) build $(BYOH_TEMPLATES)/v1beta1/templates/e2e/installer --load-restrictor LoadRestrictionsNone > $(BYOH_TEMPLATES)/v1beta1/templates/e2e/installer/cluster-template.yaml
 
 define WARNING
 #####################################################################################################

--- a/common/installer/internal/algo/ubuntu20_4k8s.go
+++ b/common/installer/internal/algo/ubuntu20_4k8s.go
@@ -114,7 +114,7 @@ modprobe overlay && modprobe br_netfilter
 tar -C / -xvf "$BUNDLE_PATH/conf.tar" && sysctl --system 
 
 ## installing deb packages
-for pkg in cri-tools kubernetes-cni kubectl kubeadm kubelet; do
+for pkg in cri-tools kubernetes-cni kubectl kubelet kubeadm; do
 	dpkg --install "$BUNDLE_PATH/$pkg.deb" && apt-mark hold $pkg
 done
 

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/cluster-template.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/cluster-template.yaml
@@ -1,0 +1,241 @@
+apiVersion: v1
+binaryData: null
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+  - kind: ConfigMap
+    name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
+    crs: "true"
+  name: ${CLUSTER_NAME}
+spec:
+  clusterNetwork:
+    pods:
+      cidrBlocks:
+      - 192.168.0.0/16
+    serviceDomain: cluster.local
+    services:
+      cidrBlocks:
+      - 10.128.0.0/12
+  controlPlaneRef:
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    kind: KubeadmControlPlane
+    name: ${CLUSTER_NAME}-control-plane
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: ByoCluster
+    name: ${CLUSTER_NAME}
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels: null
+  template:
+    metadata:
+      labels:
+        nodepool: pool1
+    spec:
+      bootstrap:
+        configRef:
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+          name: ${CLUSTER_NAME}-md-0
+      clusterName: ${CLUSTER_NAME}
+      infrastructureRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: ByoMachineTemplate
+        name: ${CLUSTER_NAME}-md-0
+      version: ${KUBERNETES_VERSION}
+---
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+kind: KubeadmControlPlane
+metadata:
+  labels:
+    nodepool: pool0
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      apiServer:
+        certSANs:
+        - localhost
+        - 127.0.0.1
+        - 0.0.0.0
+        - host.docker.internal
+      controllerManager:
+        extraArgs:
+          enable-hostpath-provisioner: "true"
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: cp_enable
+              value: "true"
+            - name: vip_arp
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_address
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
+            - name: vip_interface
+              value: {{ .DefaultNetworkInterfaceName }}
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            image: ghcr.io/kube-vip/kube-vip:v0.4.1
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          hostAliases:
+            - hostnames:
+                - kubernetes
+              ip: 127.0.0.1
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+              type: FileOrCreate
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    joinConfiguration:
+      nodeRegistration:
+        criSocket: /var/run/containerd/containerd.sock
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  machineTemplate:
+    infrastructureRef:
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      kind: ByoMachineTemplate
+      name: ${CLUSTER_NAME}-control-plane
+      namespace: ${NAMESPACE}
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+  bundleLookupTag: ${BUNDLE_LOOKUP_TAG}
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
+    port: 6443
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: ${CLUSTER_NAME}-control-plane
+        namespace: ${NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: ${CLUSTER_NAME}-md-0
+        namespace: ${NAMESPACE}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/cluster-with-kcp.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/cluster-with-kcp.yaml
@@ -1,0 +1,153 @@
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: Cluster
+metadata:
+  name: ${CLUSTER_NAME}
+  labels:
+    cni: ${CLUSTER_NAME}-crs-0
+    crs: "true"
+spec:
+  clusterNetwork:
+    services:
+      cidrBlocks: ["10.128.0.0/12"]
+    pods:
+      cidrBlocks: ["192.168.0.0/16"]
+    serviceDomain: "cluster.local"
+  infrastructureRef:
+    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+    kind: ByoCluster
+    name: ${CLUSTER_NAME}
+  controlPlaneRef:
+    kind: KubeadmControlPlane
+    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+    name: "${CLUSTER_NAME}-control-plane"
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoCluster
+metadata:
+  name: ${CLUSTER_NAME}
+spec:
+  bundleLookupBaseRegistry: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+  bundleLookupTag: ${BUNDLE_LOOKUP_TAG}
+  controlPlaneEndpoint:
+    host: ${CONTROL_PLANE_ENDPOINT_IP}
+    port: 6443
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: "${CLUSTER_NAME}-control-plane"
+        namespace: "${NAMESPACE}"
+---
+kind: KubeadmControlPlane
+apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+metadata:
+  name: "${CLUSTER_NAME}-control-plane"
+  labels:
+    nodepool: "pool0"
+spec:
+  replicas: ${CONTROL_PLANE_MACHINE_COUNT}
+  machineTemplate:
+    infrastructureRef:
+      kind: ByoMachineTemplate
+      apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+      name: "${CLUSTER_NAME}-control-plane"
+      namespace: "${NAMESPACE}"
+  kubeadmConfigSpec:
+    clusterConfiguration:
+      controllerManager:
+        extraArgs: {enable-hostpath-provisioner: 'true'}
+      apiServer:
+        certSANs: [localhost, 127.0.0.1, 0.0.0.0, host.docker.internal]
+    files:
+    - content: |
+        apiVersion: v1
+        kind: Pod
+        metadata:
+          creationTimestamp: null
+          name: kube-vip
+          namespace: kube-system
+        spec:
+          containers:
+          - args:
+            - manager
+            env:
+            - name: cp_enable
+              value: "true"
+            - name: vip_arp
+              value: "true"
+            - name: vip_leaderelection
+              value: "true"
+            - name: vip_address
+              value: ${CONTROL_PLANE_ENDPOINT_IP}
+            - name: vip_interface
+              value: {{ .DefaultNetworkInterfaceName }}
+            - name: vip_leaseduration
+              value: "15"
+            - name: vip_renewdeadline
+              value: "10"
+            - name: vip_retryperiod
+              value: "2"
+            image: ghcr.io/kube-vip/kube-vip:v0.4.1
+            imagePullPolicy: IfNotPresent
+            name: kube-vip
+            resources: {}
+            securityContext:
+              capabilities:
+                add:
+                - NET_ADMIN
+                - NET_RAW
+            volumeMounts:
+            - mountPath: /etc/kubernetes/admin.conf
+              name: kubeconfig
+          hostNetwork: true
+          hostAliases:
+            - hostnames:
+                - kubernetes
+              ip: 127.0.0.1
+          volumes:
+          - hostPath:
+              path: /etc/kubernetes/admin.conf
+              type: FileOrCreate
+            name: kubeconfig
+        status: {}
+      owner: root:root
+      path: /etc/kubernetes/manifests/kube-vip.yaml
+    initConfiguration:
+      nodeRegistration:
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+    joinConfiguration:
+      nodeRegistration:
+        ignorePreflightErrors:
+        - Swap
+        - DirAvailable--etc-kubernetes-manifests
+        - FileAvailable--etc-kubernetes-kubelet.conf
+        criSocket: /var/run/containerd/containerd.sock
+        kubeletExtraArgs:
+          cgroup-driver: cgroupfs
+          eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+  version: ${KUBERNETES_VERSION}
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-control-plane
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/crs.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/crs.yaml
@@ -1,0 +1,21 @@
+
+---
+apiVersion: v1
+binaryData: null
+data: ${CNI_RESOURCES}
+kind: ConfigMap
+metadata:
+  name: cni-${CLUSTER_NAME}-crs-0
+---
+apiVersion: addons.cluster.x-k8s.io/v1beta1
+kind: ClusterResourceSet
+metadata:
+  name: ${CLUSTER_NAME}-crs-0
+spec:
+  clusterSelector:
+    matchLabels:
+      cni: ${CLUSTER_NAME}-crs-0
+  resources:
+    - kind: ConfigMap
+      name: cni-${CLUSTER_NAME}-crs-0
+  strategy: ApplyOnce

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/kustomization.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/kustomization.yaml
@@ -1,0 +1,4 @@
+bases:
+  - cluster-with-kcp.yaml
+  - crs.yaml
+  - md.yaml

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/md.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/e2e/installer/md.yaml
@@ -1,0 +1,63 @@
+
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: ByoMachineTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      installerRef:
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: K8sInstallerConfigTemplate
+        name: "${CLUSTER_NAME}-md-0"
+        namespace: "${NAMESPACE}"
+---
+apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+kind: KubeadmConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      joinConfiguration:
+        nodeRegistration:
+          kubeletExtraArgs:
+            cgroup-driver: cgroupfs
+            eviction-hard: nodefs.available<0%,nodefs.inodesFree<0%,imagefs.available<0%
+---
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineDeployment
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  clusterName: ${CLUSTER_NAME}
+  replicas: ${WORKER_MACHINE_COUNT}
+  selector:
+    matchLabels:
+  template:
+    metadata:
+      labels:
+        nodepool: "pool1"
+    spec:
+      clusterName: ${CLUSTER_NAME}
+      version: ${KUBERNETES_VERSION}
+      bootstrap:
+        configRef:
+          name: ${CLUSTER_NAME}-md-0
+          apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
+          kind: KubeadmConfigTemplate
+      infrastructureRef:
+        name: ${CLUSTER_NAME}-md-0
+        apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+        kind: ByoMachineTemplate
+---
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: K8sInstallerConfigTemplate
+metadata:
+  name: ${CLUSTER_NAME}-md-0
+spec:
+  template:
+    spec:
+      bundleRepo: projects.registry.vmware.com/cluster_api_provider_bringyourownhost
+      bundleType: k8s

--- a/test/e2e/e2e_installer_test.go
+++ b/test/e2e/e2e_installer_test.go
@@ -1,0 +1,177 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+// nolint: testpackage
+package e2e
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/client"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/cluster-api/test/framework/clusterctl"
+	"sigs.k8s.io/cluster-api/util"
+)
+
+// creating a workload cluster
+// This test is meant to provide a first, fast signal to detect regression; it is recommended to use it as a PR blocker test.
+var _ = Describe("When BYOH joins existing cluster [Installer]", func() {
+
+	var (
+		ctx                 context.Context
+		specName            = "quick-start"
+		namespace           *corev1.Namespace
+		clusterName         string
+		cancelWatches       context.CancelFunc
+		clusterResources    *clusterctl.ApplyClusterTemplateAndWaitResult
+		dockerClient        *client.Client
+		err                 error
+		byohostContainerIDs []string
+		agentLogFile1       = "/tmp/host-agent1.log"
+		agentLogFile2       = "/tmp/host-agent2.log"
+		byoHostName1        = "byohost1"
+		byoHostName2        = "byohost2"
+	)
+
+	BeforeEach(func() {
+
+		ctx = context.TODO()
+		Expect(ctx).NotTo(BeNil(), "ctx is required for %s spec", specName)
+
+		Expect(e2eConfig).NotTo(BeNil(), "Invalid argument. e2eConfig can't be nil when calling %s spec", specName)
+		Expect(clusterctlConfigPath).To(BeAnExistingFile(), "Invalid argument. clusterctlConfigPath must be an existing file when calling %s spec", specName)
+		Expect(bootstrapClusterProxy).NotTo(BeNil(), "Invalid argument. bootstrapClusterProxy can't be nil when calling %s spec", specName)
+		Expect(os.MkdirAll(artifactFolder, 0755)).To(Succeed(), "Invalid argument. artifactFolder can't be created for %s spec", specName)
+
+		Expect(e2eConfig.Variables).To(HaveKey(KubernetesVersion))
+
+		// set up a Namespace where to host objects for this spec and create a watcher for the namespace events.
+		namespace, cancelWatches = setupSpecNamespace(ctx, specName, bootstrapClusterProxy, artifactFolder)
+		clusterResources = new(clusterctl.ApplyClusterTemplateAndWaitResult)
+	})
+
+	It("Should create a workload cluster with single BYOH host", func() {
+		clusterName = fmt.Sprintf("%s-%s", specName, util.RandomString(6))
+
+		dockerClient, err = client.NewClientWithOpts(client.FromEnv)
+		Expect(err).NotTo(HaveOccurred())
+
+		runner := ByoHostRunner{
+			Context:               ctx,
+			clusterConName:        clusterConName,
+			Namespace:             namespace.Name,
+			PathToHostAgentBinary: pathToHostAgentBinary,
+			DockerClient:          dockerClient,
+			NetworkInterface:      "kind",
+			bootstrapClusterProxy: bootstrapClusterProxy,
+			CommandArgs: map[string]string{
+				"--kubeconfig":               "/mgmt.conf",
+				"--namespace":                namespace.Name,
+				"--v":                        "1",
+				"--use-installer-controller": "true",
+			},
+		}
+
+		var output types.HijackedResponse
+		runner.ByoHostName = byoHostName1
+		byohost, err := runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err := runner.ExecByoDockerHost(byohost)
+		Expect(err).NotTo(HaveOccurred())
+		defer output.Close()
+		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
+		f := WriteDockerLog(output, agentLogFile1)
+		defer func() {
+			deferredErr := f.Close()
+			if deferredErr != nil {
+				Showf("error closing file %s: %v", agentLogFile1, deferredErr)
+			}
+		}()
+
+		runner.ByoHostName = byoHostName2
+		byohost, err = runner.SetupByoDockerHost()
+		Expect(err).NotTo(HaveOccurred())
+		output, byohostContainerID, err = runner.ExecByoDockerHost(byohost)
+		Expect(err).NotTo(HaveOccurred())
+		defer output.Close()
+		byohostContainerIDs = append(byohostContainerIDs, byohostContainerID)
+
+		// read the log of host agent container in backend, and write it
+		f = WriteDockerLog(output, agentLogFile2)
+		defer func() {
+			deferredErr := f.Close()
+			if deferredErr != nil {
+				Showf("error closing file %s: %v", agentLogFile2, deferredErr)
+			}
+		}()
+
+		setControlPlaneIP(context.Background(), dockerClient)
+		clusterctl.ApplyClusterTemplateAndWait(ctx, clusterctl.ApplyClusterTemplateAndWaitInput{
+			ClusterProxy: bootstrapClusterProxy,
+			ConfigCluster: clusterctl.ConfigClusterInput{
+				LogFolder:                filepath.Join(artifactFolder, "clusters", bootstrapClusterProxy.GetName()),
+				ClusterctlConfigPath:     clusterctlConfigPath,
+				KubeconfigPath:           bootstrapClusterProxy.GetKubeconfigPath(),
+				InfrastructureProvider:   clusterctl.DefaultInfrastructureProvider,
+				Flavor:                   clusterctl.DefaultFlavor,
+				Namespace:                namespace.Name,
+				ClusterName:              clusterName,
+				KubernetesVersion:        e2eConfig.GetVariable(KubernetesVersion),
+				ControlPlaneMachineCount: pointer.Int64Ptr(1),
+				WorkerMachineCount:       pointer.Int64Ptr(1),
+			},
+			WaitForClusterIntervals:      e2eConfig.GetIntervals(specName, "wait-cluster"),
+			WaitForControlPlaneIntervals: e2eConfig.GetIntervals(specName, "wait-control-plane"),
+			WaitForMachineDeployments:    e2eConfig.GetIntervals(specName, "wait-worker-nodes"),
+		}, clusterResources)
+
+	})
+
+	JustAfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			ShowInfo([]string{agentLogFile1, agentLogFile2})
+		}
+	})
+
+	AfterEach(func() {
+		// Dumps all the resources in the spec namespace, then cleanups the cluster object and the spec namespace itself.
+		dumpSpecResourcesAndCleanup(ctx, specName, bootstrapClusterProxy, artifactFolder, namespace, cancelWatches, clusterResources.Cluster, e2eConfig.GetIntervals, skipCleanup)
+
+		if dockerClient != nil && len(byohostContainerIDs) != 0 {
+			for _, byohostContainerID := range byohostContainerIDs {
+				err := dockerClient.ContainerStop(ctx, byohostContainerID, nil)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = dockerClient.ContainerRemove(ctx, byohostContainerID, types.ContainerRemoveOptions{})
+				Expect(err).NotTo(HaveOccurred())
+			}
+		}
+
+		err := os.Remove(agentLogFile1)
+		if err != nil {
+			Showf("error removing file %s: %v", agentLogFile1, err)
+		}
+
+		err = os.Remove(agentLogFile2)
+		if err != nil {
+			Showf("error removing file %s: %v", agentLogFile2, err)
+		}
+
+		err = os.Remove(ReadByohControllerManagerLogShellFile)
+		if err != nil {
+			Showf("error removing file %s: %v", ReadByohControllerManagerLogShellFile, err)
+		}
+
+		err = os.Remove(ReadAllPodsShellFile)
+		if err != nil {
+			Showf("error removing file %s: %v", ReadAllPodsShellFile, err)
+		}
+	})
+})


### PR DESCRIPTION
Signed-off-by: Shubham <shbajpai@vmware.com>

**What this PR does / why we need it**:
This PR adds e2e test for the new [installer flow](https://github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/blob/main/docs/diagrams/installer-flow.png) of provisioning workload cluster. This flow will replace the current way of provisioning so keeping that in mind few choices were made while implementing the test and to avoid writing complex tests which might be removed soon:
 - another cluster template was added with installer changes
 - the current test was duplicated with 1 key difference of `--use-installer-controller` enabled via host agent
 - another step was added to github action to run installer test separately as the both cannot be run together due to difference in cluster template
 - to reuse the same provider.yaml file `sed` the template path before running installer test.

The above choices also makes it easier to remove the old test when we decide to deprecate the old flow, which I assume is pretty soon. We can just remove the old test & template and rename/restructure some new test & templates.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #468 

**Additional information**
I was facing the below error while testing the installer flow. Reversing the order of kubelet and kubeadm in the install script fixed it
```
+ dpkg --install /var/lib/byoh/bundles/projects.registry.vmware.com/cluster_api_provider_bringyourownhost/byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.23.5/kubeadm.deb
1Selecting previously unselected package kubeadm.
G(Reading database ... 8761 files and directories currently installed.)
(Preparing to unpack .../kubeadm.deb ...
"Unpacking kubeadm (1.23.5-00) ...
�dpkg: dependency problems prevent configuration of kubeadm:
 kubeadm depends on kubelet (>= 1.19.0); however:
  Package kubelet is not installed.
dpkg: error processing package kubeadm (--install):
 dependency problems - leaving unconfigured
```

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->