### PR TITLE
Advanced workflow for complete e2e

### DIFF
--- a/.github/workflows/run-all-e2e-test.yaml
+++ b/.github/workflows/run-all-e2e-test.yaml
@@ -1,0 +1,32 @@
+name: All e2e tests
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ labeled ]
+
+jobs:
+  e2e-full:
+    if: ${{ github.event.label.name == 'pr/run-all-e2e-test' }}
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Install ginkgo
+      run: go get github.com/onsi/ginkgo/ginkgo@v1.16.5
+
+    - name: turn off swap
+      run: sudo swapoff -a
+
+    - name: Set netfilter conntrack max
+      run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
+
+    - name: Run PR-Blocking e2e tests
+      run: yes | make test-e2e


### PR DESCRIPTION
**What this PR does / why we need it**:
This workflow is needed when we want to run full e2e tests for the PR before merging.

**Additional information**
We have to add label `pr/run-all-e2e-test` to run all the e2e tests on the PR.

**Special notes for your reviewer**

I tried many different implementations-
1. Using flag `/test-full-e2e` to run e2e test but it failed as the event was triggered but was not updating in checks in the PR.
2. Using flag `/test-full-e2e` to create a workflow to add label to PR by Github bot and then running the e2e tests but it failed becoz a GitHub workflow cannot trigger another workflow.