### PR TITLE
Fix agent to mark conditions with appropriate status on uninstall

### DIFF
--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -285,6 +285,8 @@ func (r *HostReconciler) hostCleanUp(ctx context.Context, byoHost *infrastructur
 				r.Recorder.Event(byoHost, corev1.EventTypeWarning, "UninstallScriptExecutionFailed", "uninstall script execution failed")
 				return err
 			}
+			conditions.MarkFalse(byoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded, infrastructurev1beta1.K8sNodeAbsentReason, clusterv1.ConditionSeverityInfo, "")
+			logger.Info("host removed from the cluster and the uninstall is executed successfully")
 		} else {
 			err = r.uninstallk8sComponents(ctx, byoHost)
 			if err != nil {

--- a/agent/reconciler/reconciler_test.go
+++ b/agent/reconciler/reconciler_test.go
@@ -622,9 +622,9 @@ runCmd:
 					err := k8sClient.Get(ctx, byoHostLookupKey, updatedByoHost)
 					Expect(err).ToNot(HaveOccurred())
 
-					K8sNodeBootstrapSucceeded := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sNodeBootstrapSucceeded)
-					Expect(*K8sNodeBootstrapSucceeded).To(conditions.MatchCondition(clusterv1.Condition{
-						Type:     infrastructurev1beta1.K8sNodeBootstrapSucceeded,
+					K8sComponentsInstallationSucceeded := conditions.Get(updatedByoHost, infrastructurev1beta1.K8sComponentsInstallationSucceeded)
+					Expect(*K8sComponentsInstallationSucceeded).To(conditions.MatchCondition(clusterv1.Condition{
+						Type:     infrastructurev1beta1.K8sComponentsInstallationSucceeded,
 						Status:   corev1.ConditionFalse,
 						Reason:   infrastructurev1beta1.K8sNodeAbsentReason,
 						Severity: clusterv1.ConditionSeverityInfo,


### PR DESCRIPTION
Signed-off-by: Shubham <shbajpai@vmware.com>

**What this PR does / why we need it**:

This PR marks the K8sComponentsInstallationSucceeded condition as false whenever a host a removed from the cluster and the uninstall is executed successfully. It also fixes an existing test by asserting the correct condition for it's status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #585 

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->