### PR TITLE
Update ByoHost Validating webhook

### DIFF
--- a/apis/infrastructure/v1beta1/byohost_webhook_internal_test.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook_internal_test.go
@@ -1,0 +1,198 @@
+// Copyright 2021 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	admissionv1 "k8s.io/api/admission/v1"
+	v1 "k8s.io/api/authentication/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("ByohostWebhook/Unit", func() {
+	schema := runtime.NewScheme()
+	err := AddToScheme(schema)
+	Expect(err).NotTo(HaveOccurred())
+	decoder, _ := admission.NewDecoder(schema)
+	v := &ByoHostValidator{
+		decoder: decoder,
+	}
+	Context("When ByoHost gets a create request", func() {
+		var (
+			byoHost    *ByoHost
+			byoHostRaw []byte
+			ctx        context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.TODO()
+			byoHost = &ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+				},
+				Spec: ByoHostSpec{},
+			}
+			byoHostRaw, err = json.Marshal(byoHost)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Should reject create request from invalid user", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				UserInfo:  v1.UserInfo{Username: "unauthorized-user"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(false))
+			Expect(string(resp.AdmissionResponse.Result.Reason)).To(Equal(fmt.Sprintf("%s is not a valid agent username", "unauthorized-user")))
+		})
+		It("Should reject request from another agent user in the group", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				UserInfo:  v1.UserInfo{Username: "byoh:host:host2"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(false))
+			Expect(string(resp.AdmissionResponse.Result.Reason)).To(Equal(fmt.Sprintf("%s cannot create/update resource %s", "byoh:host:host2", "host1")))
+		})
+		It("Should allow request from the valid agent user", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Create,
+				UserInfo:  v1.UserInfo{Username: "byoh:host:host1"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(true))
+		})
+	})
+
+	Context("When ByoHost gets an update request", func() {
+		var (
+			byoHost    *ByoHost
+			byoHostRaw []byte
+			ctx        context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.TODO()
+			byoHost = &ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+				},
+				Spec: ByoHostSpec{},
+			}
+			byoHostRaw, err = json.Marshal(byoHost)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Should reject update request from invalid user", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UserInfo:  v1.UserInfo{Username: "unauthorized-user"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(false))
+			Expect(string(resp.AdmissionResponse.Result.Reason)).To(Equal(fmt.Sprintf("%s is not a valid agent username", "unauthorized-user")))
+		})
+		It("Should allow update request from manager", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UserInfo:  v1.UserInfo{Username: managerServiceAccount},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(true))
+		})
+		It("Should reject request from another agent user in the group", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UserInfo:  v1.UserInfo{Username: "byoh:host:host2"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(false))
+			Expect(string(resp.AdmissionResponse.Result.Reason)).To(Equal(fmt.Sprintf("%s cannot create/update resource %s", "byoh:host:host2", "host1")))
+		})
+		It("Should allow request from the valid agent user", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Update,
+				UserInfo:  v1.UserInfo{Username: "byoh:host:host1"},
+				Object: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(true))
+		})
+	})
+	Context("When ByoHost gets an delete request", func() {
+		var (
+			byoHost    *ByoHost
+			byoHostRaw []byte
+			ctx        context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.TODO()
+			byoHost = &ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+				},
+				Spec: ByoHostSpec{},
+			}
+			byoHostRaw, err = json.Marshal(byoHost)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+		It("Should allow delete request from any user", func() {
+			admissionRequest := admissionv1.AdmissionRequest{
+				Operation: admissionv1.Delete,
+				UserInfo:  v1.UserInfo{Username: "random-user"},
+				OldObject: runtime.RawExtension{
+					Raw:    byoHostRaw,
+					Object: byoHost,
+				},
+			}
+			resp := v.Handle(ctx, admission.Request{AdmissionRequest: admissionRequest})
+			Expect(resp.AdmissionResponse.Allowed).To(Equal(true))
+		})
+	})
+})

--- a/apis/infrastructure/v1beta1/byohost_webhook_test.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook_test.go
@@ -11,6 +11,7 @@ import (
 	byohv1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/kubectl/pkg/scheme"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,43 +21,39 @@ var _ = Describe("ByohostWebhook", func() {
 
 	Context("When ByoHost gets a delete request", func() {
 		var (
-			byoHost           *byohv1beta1.ByoHost
-			ctx               context.Context
-			k8sClientUncached client.Client
+			byoHost *byohv1beta1.ByoHost
+			ctx     context.Context
 		)
 		BeforeEach(func() {
 			ctx = context.Background()
-			var clientErr error
-
-			k8sClientUncached, clientErr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
-			Expect(clientErr).NotTo(HaveOccurred())
-
 			byoHost = &byohv1beta1.ByoHost{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       "ByoHost",
 					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "byohost-",
-					Namespace:    "default",
+					Name:      "host1",
+					Namespace: "default",
 				},
 				Spec: byohv1beta1.ByoHostSpec{},
 			}
-			Expect(k8sClientUncached.Create(ctx, byoHost)).Should(Succeed())
-
+			Expect(ValidUserK8sClient.Create(ctx, byoHost)).Should(Succeed())
 		})
 
 		It("should not reject the request", func() {
-
-			err := k8sClientUncached.Delete(ctx, byoHost)
+			err := ValidUserK8sClient.Delete(ctx, byoHost)
 			Expect(err).To(BeNil())
 		})
 
 		Context("When ByoHost has MachineRef assigned", func() {
 			var (
-				byoMachine *byohv1beta1.ByoMachine
+				byoMachine        *byohv1beta1.ByoMachine
+				k8sClientUncached client.Client
 			)
 			BeforeEach(func() {
+				var clientErr error
+				k8sClientUncached, clientErr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+				Expect(clientErr).NotTo(HaveOccurred())
 				byoMachine = &byohv1beta1.ByoMachine{
 					TypeMeta: metav1.TypeMeta{
 						Kind:       "ByoMachine",
@@ -70,7 +67,7 @@ var _ = Describe("ByohostWebhook", func() {
 				}
 				Expect(k8sClientUncached.Create(ctx, byoMachine)).Should(Succeed())
 
-				ph, err := patch.NewHelper(byoHost, k8sClientUncached)
+				ph, err := patch.NewHelper(byoHost, ValidUserK8sClient)
 				Expect(err).ShouldNot(HaveOccurred())
 				byoHost.Status.MachineRef = &corev1.ObjectReference{
 					Kind:       "ByoMachine",
@@ -80,15 +77,94 @@ var _ = Describe("ByohostWebhook", func() {
 					APIVersion: byoHost.APIVersion,
 				}
 				Expect(ph.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).Should(Succeed())
-
 			})
 
 			It("should reject the request", func() {
-				err := k8sClientUncached.Delete(ctx, byoHost)
+				err := ValidUserK8sClient.Delete(ctx, byoHost)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(MatchError("admission webhook \"vbyohost.kb.io\" denied the request: cannot delete ByoHost when MachineRef is assigned"))
 			})
+
+			AfterEach(func() {
+				// delete the byohost resource
+				ph, err := patch.NewHelper(byoHost, ValidUserK8sClient)
+				Expect(err).ShouldNot(HaveOccurred())
+				byoHost.Status.MachineRef = nil
+				Expect(ph.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).Should(Succeed())
+				Expect(ValidUserK8sClient.Delete(ctx, byoHost)).Should(Succeed())
+			})
 		})
 	})
+	Context("When ByoHost gets a create request", func() {
+		var (
+			byoHost *byohv1beta1.ByoHost
+			ctx     context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			byoHost = &byohv1beta1.ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+				},
+				Spec: byohv1beta1.ByoHostSpec{},
+			}
+		})
 
+		It("should allow the request from a valid user", func() {
+			Expect(ValidUserK8sClient.Create(ctx, byoHost)).Should(Succeed())
+			// cleanup
+			Expect(ValidUserK8sClient.Delete(ctx, byoHost)).Should(Succeed())
+		})
+
+		It("should reject the request from an invalid user", func() {
+			err := InvalidUserK8sClient.Create(ctx, byoHost)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not a valid agent username"))
+		})
+	})
+	Context("When ByoHost gets a update request", func() {
+		var (
+			byoHost *byohv1beta1.ByoHost
+			ctx     context.Context
+		)
+		BeforeEach(func() {
+			ctx = context.Background()
+			byoHost = &byohv1beta1.ByoHost{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ByoHost",
+					APIVersion: "infrastructure.cluster.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "host1",
+					Namespace: "default",
+				},
+				Spec: byohv1beta1.ByoHostSpec{},
+			}
+			Expect(ValidUserK8sClient.Create(ctx, byoHost)).Should(Succeed())
+		})
+		It("should allow the request from a valid user", func() {
+			arch := "amd64"
+			byoHost.Status.HostDetails.Architecture = arch
+			Expect(ValidUserK8sClient.Update(ctx, byoHost)).Should(Succeed())
+			Eventually(func() (done bool) {
+				updatedByoHost := &byohv1beta1.ByoHost{}
+				err := ValidUserK8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "host1"}, updatedByoHost)
+				Expect(err).ShouldNot(HaveOccurred())
+				return updatedByoHost.Status.HostDetails.Architecture == arch
+			})
+		})
+		It("should reject the request from an invalid user", func() {
+			err := InvalidUserK8sClient.Update(ctx, byoHost)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("is not a valid agent username"))
+		})
+		AfterEach(func() {
+			Expect(ValidUserK8sClient.Delete(ctx, byoHost)).Should(Succeed())
+		})
+	})
 })

--- a/apis/infrastructure/v1beta1/webhook_suite_test.go
+++ b/apis/infrastructure/v1beta1/webhook_suite_test.go
@@ -91,7 +91,10 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
-	// apply Custom RBAC
+	// Apply Custom RBAC
+	// This is required as in the envtest there is no default API
+	// to include RBAC. We are using a helper func parseK8sYaml to manually
+	// achieve this.
 	rbacDir := filepath.Join("..", "..", "..", "config", "rbac")
 	files, err := os.ReadDir(rbacDir)
 	Expect(err).ShouldNot(HaveOccurred())

--- a/apis/infrastructure/v1beta1/webhook_suite_test.go
+++ b/apis/infrastructure/v1beta1/webhook_suite_test.go
@@ -8,7 +8,10 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -17,6 +20,7 @@ import (
 	byohv1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubectl/pkg/scheme"
 
 	//+kubebuilder:scaffold:imports
@@ -35,12 +39,13 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var (
-	cfg               *rest.Config
-	k8sClient         client.Client
-	testUserK8sClient client.Client
-	testEnv           *envtest.Environment
-	ctx               context.Context
-	cancel            context.CancelFunc
+	cfg                  *rest.Config
+	k8sClient            client.Client
+	InvalidUserK8sClient client.Client
+	ValidUserK8sClient   client.Client
+	testEnv              *envtest.Environment
+	ctx                  context.Context
+	cancel               context.CancelFunc
 )
 
 func TestAPIs(t *testing.T) {
@@ -71,7 +76,6 @@ var _ = BeforeSuite(func() {
 	Expect(cfg).NotTo(BeNil())
 
 	err = byohv1beta1.AddToScheme(scheme.Scheme)
-
 	Expect(err).NotTo(HaveOccurred())
 
 	err = admissionv1beta1.AddToScheme(scheme.Scheme)
@@ -87,6 +91,25 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
+	// apply Custom RBAC
+	rbacDir := filepath.Join("..", "..", "..", "config", "rbac")
+	files, err := os.ReadDir(rbacDir)
+	Expect(err).ShouldNot(HaveOccurred())
+	for _, f := range files {
+		bytes, ferr := os.ReadFile(filepath.Join(rbacDir, f.Name()))
+		if ferr != nil {
+			fmt.Println(ferr)
+			continue
+		}
+		obj := parseK8sYaml(bytes)
+		if len(obj) < 1 {
+			continue
+		}
+		err = k8sClient.Create(ctx, obj[0].(client.Object))
+		if err != nil {
+			continue
+		}
+	}
 	// start webhook server using Manager
 	webhookInstallOptions := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -98,13 +121,22 @@ var _ = BeforeSuite(func() {
 		MetricsBindAddress: "0",
 	})
 	Expect(err).NotTo(HaveOccurred())
-	user, err := testEnv.ControlPlane.AddUser(envtest.User{
+	invalidUser, err := testEnv.ControlPlane.AddUser(envtest.User{
 		Name:   "test-user",
 		Groups: []string{"byoh:hosts"},
 	}, nil)
 	Expect(err).NotTo(HaveOccurred())
 
-	testUserK8sClient, err = client.New(user.Config(), client.Options{Scheme: scheme.Scheme})
+	InvalidUserK8sClient, err = client.New(invalidUser.Config(), client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(k8sClient).NotTo(BeNil())
+
+	validUser, err := testEnv.ControlPlane.AddUser(envtest.User{
+		Name:   "byoh:host:host1",
+		Groups: []string{"byoh:hosts"},
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+	ValidUserK8sClient, err = client.New(validUser.Config(), client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
@@ -141,3 +173,29 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).NotTo(HaveOccurred())
 })
+
+// ref: https://github.com/kubernetes/client-go/issues/193#issuecomment-363318588
+func parseK8sYaml(fileR []byte) []runtime.Object {
+	acceptedK8sTypes := regexp.MustCompile(`(Role|ClusterRole|RoleBinding|ClusterRoleBinding|ServiceAccount)`)
+	fileAsString := string(fileR)
+	sepYamlfiles := strings.Split(fileAsString, "---")
+	retVal := make([]runtime.Object, 0, len(sepYamlfiles))
+	for _, f := range sepYamlfiles {
+		if f == "\n" || f == "" {
+			// ignore empty cases
+			continue
+		}
+		decode := scheme.Codecs.UniversalDeserializer().Decode
+		obj, groupVersionKind, err := decode([]byte(f), nil, nil)
+		if err != nil {
+			fmt.Printf("Error while decoding YAML object")
+			continue
+		}
+		if !acceptedK8sTypes.MatchString(groupVersionKind.Kind) {
+			fmt.Printf("Skipping object with type: %s\n", groupVersionKind.Kind)
+		} else {
+			retVal = append(retVal, obj)
+		}
+	}
+	return retVal
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the existing `ByoHost` validating webhook for authorization rules. Unit tests are also added along with integration tests.
Authz rules
- Update op will be allowed for the ByoHost owner agent user or controller manager service account.
- Create op will be allowed for the resource owner agent user
- Reads/Deletes are allowed to any user.

**Which issue(s) this PR fixes** :
Fixes #514 