### PR TITLE
Added clusterclass template in release

### DIFF
--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -31,7 +31,11 @@ jobs:
           files: |
             _dist/byoh-hostagent-linux-amd64
             _dist/cluster-template.yaml
+            _dist/cluster-template-topology.yaml
+            _dist/clusterclass-quickstart.yaml
             _dist/cluster-template-docker.yaml
+            _dist/cluster-template-topology-docker.yaml
+            _dist/clusterclass-quickstart-docker.yaml
             _dist/infrastructure-components.yaml
             _dist/metadata.yaml
         env:

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,11 @@ build-release-artifacts: build-cluster-templates build-infra-yaml build-metadata
 
 build-cluster-templates: $(RELEASE_DIR) cluster-templates
 	cp $(BYOH_TEMPLATES)/v1beta1/templates/docker/cluster-template.yaml $(RELEASE_DIR)/cluster-template-docker.yaml
+	cp $(BYOH_TEMPLATES)/v1beta1/templates/docker/cluster-template-topology-docker.yaml $(RELEASE_DIR)/cluster-template-topology-docker.yaml
+	cp $(BYOH_TEMPLATES)/v1beta1/templates/docker/clusterclass-quickstart-docker.yaml $(RELEASE_DIR)/clusterclass-quickstart-docker.yaml
 	cp $(BYOH_TEMPLATES)/v1beta1/templates/vm/cluster-template.yaml $(RELEASE_DIR)/cluster-template.yaml
+	cp $(BYOH_TEMPLATES)/v1beta1/templates/vm/cluster-template-topology.yaml $(RELEASE_DIR)/cluster-template-topology.yaml
+	cp $(BYOH_TEMPLATES)/v1beta1/templates/vm/clusterclass-quickstart.yaml $(RELEASE_DIR)/clusterclass-quickstart.yaml
 
 
 build-infra-yaml:kustomize # Generate infrastructure-components.yaml for the provider

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template-topology-docker.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/cluster-template-topology-docker.yaml
@@ -13,7 +13,7 @@ spec:
         - 192.168.0.0/16
     serviceDomain: cluster.local
   topology:
-    class: quickstart
+    class: quickstart-docker
     version: ${KUBERNETES_VERSION}
     controlPlane:
       metadata: {}
@@ -77,7 +77,7 @@ spec:
           status: {}
     workers:
       machineDeployments:
-        - class: quickstart-worker
+        - class: quickstart-docker-worker
           metadata: {}
           name: md-0
           replicas: ${WORKER_MACHINE_COUNT}

--- a/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/clusterclass-quickstart-docker.yaml
+++ b/test/e2e/data/infrastructure-provider-byoh/v1beta1/templates/docker/clusterclass-quickstart-docker.yaml
@@ -2,37 +2,37 @@
 apiVersion: cluster.x-k8s.io/v1beta1
 kind: ClusterClass
 metadata:
-  name: quickstart
+  name: quickstart-docker
 spec:
   controlPlane:
     ref:
       apiVersion: controlplane.cluster.x-k8s.io/v1beta1
       kind: KubeadmControlPlaneTemplate
-      name: quickstart-control-plane
+      name: quickstart-docker-control-plane
     machineInfrastructure:
       ref:
         kind: ByoMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-        name: quickstart-control-plane-machine
+        name: quickstart-docker-control-plane-machine
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
       kind: ByoClusterTemplate
-      name: quickstart-cluster
+      name: quickstart-docker-cluster
   workers:
     machineDeployments:
-      - class: quickstart-worker
+      - class: quickstart-docker-worker
         template:
           bootstrap:
             ref:
               apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
               kind: KubeadmConfigTemplate
-              name: quickstart-worker-bootstrap-template
+              name: quickstart-docker-worker-bootstrap-template
           infrastructure:
             ref:
               apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
               kind: ByoMachineTemplate
-              name: quickstart-worker-machinetemplate
+              name: quickstart-docker-worker-machinetemplate
   variables:
     - name: bundleLookupBaseRegistry
       required: true
@@ -98,7 +98,7 @@ apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 metadata:
   labels:
     nodepool: pool0
-  name: quickstart-control-plane
+  name: quickstart-docker-control-plane
 spec:
   template:
     spec:
@@ -140,20 +140,20 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ByoMachineTemplate
 metadata:
-  name: quickstart-control-plane-machine
+  name: quickstart-docker-control-plane-machine
 spec:
   template:
     spec:
       installerRef:
         apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
         kind: K8sInstallerConfigTemplate
-        name: quickstart-control-plane-machine
+        name: quickstart-docker-control-plane-machine
         namespace: ${NAMESPACE}
 ---
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: K8sInstallerConfigTemplate
 metadata:
-  name: quickstart-control-plane-machine
+  name: quickstart-docker-control-plane-machine
 spec:
   template:
     spec:
@@ -163,7 +163,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ByoClusterTemplate
 metadata:
-  name: quickstart-cluster
+  name: quickstart-docker-cluster
 spec:
   template:
     spec: {}
@@ -172,7 +172,7 @@ spec:
 apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
 kind: ByoMachineTemplate
 metadata:
-  name: quickstart-worker-machinetemplate
+  name: quickstart-docker-worker-machinetemplate
 spec:
   template:
     spec:
@@ -195,7 +195,7 @@ spec:
 apiVersion: bootstrap.cluster.x-k8s.io/v1beta1
 kind: KubeadmConfigTemplate
 metadata:
-  name: quickstart-worker-bootstrap-template
+  name: quickstart-docker-worker-bootstrap-template
 spec:
   template:
     spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
Added clusterclass templates in github workflow to publish them in release assets
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #591 

**Additional information**


**Special notes for your reviewer**
During release process, figured out clusterclass template name should be different for VM and docker, i.e. renamed `quickstart` to `quickstart-docker` for docker files.

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->