### PR TITLE
Update metadata version of byoh provider to v0.2.0

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,5 +2,8 @@ apiVersion: clusterctl.cluster.x-k8s.io/v1alpha3
 kind: Metadata
 releaseSeries:
   - major: 0
+    minor: 2
+    contract: v1beta1
+  - major: 0
     minor: 1
     contract: v1beta1


### PR DESCRIPTION
clusterctl cannot reference latest byoh infrastructure provider version.