### PR TITLE
Webhook for bootstrapkubeconfig

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -70,4 +70,7 @@ resources:
   kind: BootstrapKubeconfig
   path: github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1
   version: v1beta1
+  webhooks:
+    validation: true
+    webhookVersion: v1
 version: "3"

--- a/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
+++ b/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
@@ -1,0 +1,100 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1
+
+import (
+	b64 "encoding/base64"
+	"encoding/pem"
+	"net/url"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// log is for logging in this package.
+var bootstrapkubeconfiglog = logf.Log.WithName("bootstrapkubeconfig-resource")
+
+// APIServerURLScheme is the url scheme for the APIServer
+const APIServerURLScheme = "https"
+
+func (r *BootstrapKubeconfig) SetupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(r).
+		Complete()
+}
+
+//+kubebuilder:webhook:path=/validate-infrastructure-cluster-x-k8s-io-v1beta1-bootstrapkubeconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=infrastructure.cluster.x-k8s.io,resources=bootstrapkubeconfigs,verbs=create;update,versions=v1beta1,name=vbootstrapkubeconfig.kb.io,admissionReviewVersions=v1
+
+var _ webhook.Validator = &BootstrapKubeconfig{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (r *BootstrapKubeconfig) ValidateCreate() error {
+	bootstrapkubeconfiglog.Info("validate create", "name", r.Name)
+
+	if err := r.validateAPIServer(); err != nil {
+		return err
+	}
+
+	if err := r.validateCAData(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (r *BootstrapKubeconfig) ValidateUpdate(old runtime.Object) error {
+	bootstrapkubeconfiglog.Info("validate update", "name", r.Name)
+
+	if err := r.validateAPIServer(); err != nil {
+		return err
+	}
+
+	if err := r.validateCAData(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (r *BootstrapKubeconfig) ValidateDelete() error {
+	bootstrapkubeconfiglog.Info("validate delete", "name", r.Name)
+
+	// TODO(user): fill in your validation logic upon object update.
+	return nil
+}
+
+func (r *BootstrapKubeconfig) validateAPIServer() error {
+	if r.Spec.APIServer == "" {
+		return field.Invalid(field.NewPath("spec").Child("apiserver"), r.Spec.APIServer, "APIServer field cannot be empty")
+	}
+
+	parsedURL, err := url.Parse(r.Spec.APIServer)
+	if err != nil || parsedURL.Host == "" || parsedURL.Scheme != APIServerURLScheme || parsedURL.Port() == "" {
+		return field.Invalid(field.NewPath("spec").Child("apiserver"), r.Spec.APIServer, "APIServer is not of the format https://hostname:port")
+	}
+	return nil
+}
+
+func (r *BootstrapKubeconfig) validateCAData() error {
+	if r.Spec.CertificateAuthorityData == "" {
+		return field.Invalid(field.NewPath("spec").Child("caData"), r.Spec.CertificateAuthorityData, "CertificateAuthorityData field cannot be empty")
+	}
+
+	decodedCAData, err := b64.StdEncoding.DecodeString(r.Spec.CertificateAuthorityData)
+	if err != nil {
+		return field.Invalid(field.NewPath("spec").Child("caData"), r.Spec.CertificateAuthorityData, "cannot base64 decode CertificateAuthorityData")
+	}
+
+	block, _ := pem.Decode(decodedCAData)
+	if block == nil {
+		return field.Invalid(field.NewPath("spec").Child("caData"), r.Spec.CertificateAuthorityData, "CertificateAuthorityData is not PEM encoded")
+	}
+
+	return nil
+}

--- a/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
+++ b/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
@@ -74,7 +74,10 @@ func (r *BootstrapKubeconfig) validateAPIServer() error {
 	}
 
 	parsedURL, err := url.Parse(r.Spec.APIServer)
-	if err != nil || !r.isURLValid(parsedURL) {
+	if err != nil {
+		return field.Invalid(field.NewPath("spec").Child("apiserver"), r.Spec.APIServer, "APIServer URL is not valid")
+	}
+	if !r.isURLValid(parsedURL) {
 		return field.Invalid(field.NewPath("spec").Child("apiserver"), r.Spec.APIServer, "APIServer is not of the format https://hostname:port")
 	}
 	return nil

--- a/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
+++ b/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook.go
@@ -65,7 +65,6 @@ func (r *BootstrapKubeconfig) ValidateUpdate(old runtime.Object) error {
 func (r *BootstrapKubeconfig) ValidateDelete() error {
 	bootstrapkubeconfiglog.Info("validate delete", "name", r.Name)
 
-	// TODO(user): fill in your validation logic upon object update.
 	return nil
 }
 
@@ -75,7 +74,7 @@ func (r *BootstrapKubeconfig) validateAPIServer() error {
 	}
 
 	parsedURL, err := url.Parse(r.Spec.APIServer)
-	if err != nil || parsedURL.Host == "" || parsedURL.Scheme != APIServerURLScheme || parsedURL.Port() == "" {
+	if err != nil || !r.isURLValid(parsedURL) {
 		return field.Invalid(field.NewPath("spec").Child("apiserver"), r.Spec.APIServer, "APIServer is not of the format https://hostname:port")
 	}
 	return nil
@@ -97,4 +96,11 @@ func (r *BootstrapKubeconfig) validateCAData() error {
 	}
 
 	return nil
+}
+
+func (r *BootstrapKubeconfig) isURLValid(parsedURL *url.URL) bool {
+	if parsedURL.Host == "" || parsedURL.Scheme != APIServerURLScheme || parsedURL.Port() == "" {
+		return false
+	}
+	return true
 }

--- a/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook_test.go
+++ b/apis/infrastructure/v1beta1/bootstrapkubeconfig_webhook_test.go
@@ -1,0 +1,201 @@
+// Copyright 2022 VMware, Inc. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package v1beta1_test
+
+import (
+	b64 "encoding/base64"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	byohv1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
+	"github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/test/builder"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/patch"
+)
+
+var _ = Describe("BootstrapKubeconfig Webhook", func() {
+
+	var (
+		bootstrapKubeconfig         *byohv1beta1.BootstrapKubeconfig
+		err                         error
+		defaultNamespace            = "default"
+		testBootstrapKubeconfigName = "test-bootstrap-kubeconfig"
+		testServerEmpty             = ""
+		testServerWithoutScheme     = "abc.com"
+		testServerWithoutHostname   = "https://test-server"
+		testServerWithoutPort       = "https://test.com"
+		testServerValid             = "https://abc.com:1234"
+		testCADataEmpty             = ""
+		testCADataInvalid           = "test-ca-data"
+		testPEMDataInvalid          = b64.StdEncoding.EncodeToString([]byte(testCADataInvalid))
+	)
+	Context("When BootstrapKubeconfig gets a create request", func() {
+
+		It("should reject the request if APIServer field is empty", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerEmpty).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: \"\": APIServer field cannot be empty"))
+
+		})
+
+		It("should reject the request if APIServer address does not have https scheme specified", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerWithoutScheme).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: %q: APIServer is not of the format https://hostname:port", testServerWithoutScheme)))
+		})
+
+		It("should reject the request if APIServer address hostname is not specified", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerWithoutHostname).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: %q: APIServer is not of the format https://hostname:port", testServerWithoutHostname)))
+		})
+
+		It("should reject the request if APIServer address does not have the port info", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerWithoutPort).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: %q: APIServer is not of the format https://hostname:port", testServerWithoutPort)))
+		})
+
+		It("should reject the request if CertificateAuthorityData field is empty", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerValid).
+				WithCAData(testCADataEmpty).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: \"\": CertificateAuthorityData field cannot be empty"))
+
+		})
+
+		It("should reject request if CertificateAuthorityData cannot be base64 decoded", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerValid).
+				WithCAData(testCADataInvalid).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: %q: cannot base64 decode CertificateAuthorityData", testCADataInvalid)))
+
+		})
+
+		It("should reject request if CertificateAuthorityData is not PEM encoded", func() {
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerValid).
+				WithCAData(testPEMDataInvalid).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: %q: CertificateAuthorityData is not PEM encoded", testPEMDataInvalid)))
+
+		})
+
+		It("should accept the request if all fields are valid", func() {
+			// use from config of envtest
+			testCADataValid := b64.StdEncoding.EncodeToString(cfg.CAData)
+
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerValid).
+				WithCAData(testCADataValid).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Context("When BootstrapKubeconfig gets an update request", func() {
+		var (
+			ph                         *patch.Helper
+			createdBootstrapKubeconfig *byohv1beta1.BootstrapKubeconfig
+		)
+		BeforeEach(func() {
+			// use from config of envtest
+			testCADataValid := b64.StdEncoding.EncodeToString(cfg.CAData)
+
+			bootstrapKubeconfig = builder.BootstrapKubeconfig(defaultNamespace, testBootstrapKubeconfigName).
+				WithServer(testServerValid).
+				WithCAData(testCADataValid).
+				Build()
+			err = k8sClient.Create(ctx, bootstrapKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			createdBootstrapKubeconfig = &byohv1beta1.BootstrapKubeconfig{}
+			namespacedName := types.NamespacedName{Name: bootstrapKubeconfig.Name, Namespace: defaultNamespace}
+			Eventually(func() error {
+				err = k8sClient.Get(ctx, namespacedName, createdBootstrapKubeconfig)
+				if err != nil {
+					return err
+				}
+				return nil
+			}).Should(BeNil())
+
+			// create a patch helper
+			ph, err = patch.NewHelper(bootstrapKubeconfig, k8sClient)
+			Expect(err).ShouldNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			err = k8sClient.Delete(ctx, bootstrapKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reject the request if APIServer field is empty", func() {
+			createdBootstrapKubeconfig.Spec.APIServer = testServerEmpty
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: \"\": APIServer field cannot be empty"))
+
+		})
+
+		It("should reject the request if APIServer is not of the correct format", func() {
+			createdBootstrapKubeconfig.Spec.APIServer = testServerWithoutHostname
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.apiserver: Invalid value: %q: APIServer is not of the format https://hostname:port", testServerWithoutHostname)))
+		})
+
+		It("should reject the request if CertificateAuthorityData field is empty", func() {
+			createdBootstrapKubeconfig.Spec.CertificateAuthorityData = testCADataEmpty
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: \"\": CertificateAuthorityData field cannot be empty"))
+
+		})
+
+		It("should reject request if CertificateAuthorityData cannot be base64 decoded", func() {
+			createdBootstrapKubeconfig.Spec.CertificateAuthorityData = testCADataInvalid
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: %q: cannot base64 decode CertificateAuthorityData", testCADataInvalid)))
+
+		})
+
+		It("should reject request if CertificateAuthorityData is not PEM encoded", func() {
+			createdBootstrapKubeconfig.Spec.CertificateAuthorityData = testPEMDataInvalid
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(fmt.Sprintf("admission webhook \"vbootstrapkubeconfig.kb.io\" denied the request: spec.caData: Invalid value: %q: CertificateAuthorityData is not PEM encoded", testPEMDataInvalid)))
+
+		})
+
+		It("should accept the request if all fields are valid", func() {
+			// patch a valid APIServer value
+			createdBootstrapKubeconfig.Spec.APIServer = "https://1.2.3.4:5678"
+			err = ph.Patch(ctx, createdBootstrapKubeconfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/apis/infrastructure/v1beta1/byohost_webhook_test.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook_test.go
@@ -22,7 +22,6 @@ var _ = Describe("ByohostWebhook", func() {
 	Context("When ByoHost gets a delete request", func() {
 		var (
 			byoHost *byohv1beta1.ByoHost
-			ctx     context.Context
 		)
 		BeforeEach(func() {
 			ctx = context.Background()
@@ -98,7 +97,6 @@ var _ = Describe("ByohostWebhook", func() {
 	Context("When ByoHost gets a create request", func() {
 		var (
 			byoHost *byohv1beta1.ByoHost
-			ctx     context.Context
 		)
 		BeforeEach(func() {
 			ctx = context.Background()
@@ -130,7 +128,6 @@ var _ = Describe("ByohostWebhook", func() {
 	Context("When ByoHost gets a update request", func() {
 		var (
 			byoHost *byohv1beta1.ByoHost
-			ctx     context.Context
 		)
 		BeforeEach(func() {
 			ctx = context.Background()

--- a/apis/infrastructure/v1beta1/webhook_suite_test.go
+++ b/apis/infrastructure/v1beta1/webhook_suite_test.go
@@ -17,6 +17,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
 	byohv1beta1 "github.com/vmware-tanzu/cluster-api-provider-bringyourownhost/apis/infrastructure/v1beta1"
 
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -144,6 +145,9 @@ var _ = BeforeSuite(func() {
 	Expect(k8sClient).NotTo(BeNil())
 
 	mgr.GetWebhookServer().Register("/validate-infrastructure-cluster-x-k8s-io-v1beta1-byohost", &webhook.Admission{Handler: &byohv1beta1.ByoHostValidator{}})
+
+	err = (&byohv1beta1.BootstrapKubeconfig{}).SetupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
 
 	//+kubebuilder:scaffold:webhook
 

--- a/apis/infrastructure/v1beta1/zz_generated.deepcopy.go
+++ b/apis/infrastructure/v1beta1/zz_generated.deepcopy.go
@@ -11,7 +11,7 @@ package v1beta1
 import (
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	apiv1beta1 "sigs.k8s.io/cluster-api/api/v1beta1"
 )
 

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -8,6 +8,26 @@ metadata:
 webhooks:
 - admissionReviewVersions:
   - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-infrastructure-cluster-x-k8s-io-v1beta1-bootstrapkubeconfig
+  failurePolicy: Fail
+  name: vbootstrapkubeconfig.kb.io
+  rules:
+  - apiGroups:
+    - infrastructure.cluster.x-k8s.io
+    apiVersions:
+    - v1beta1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - bootstrapkubeconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
   - v1beta1
   clientConfig:
     service:

--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -835,7 +835,7 @@ var _ = Describe("Controllers/ByomachineController", func() {
 
 			It("should fail create installer config from the template", func() {
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: byoMachineLookupKey})
-				Expect(err).Should(MatchError(fmt.Sprintf("k8sinstallerconfigtemplates.infrastructure.cluster.x-k8s.io \"%s\" not found", defaultK8sInstallerConfigTemplateName)))
+				Expect(err).Should(MatchError(fmt.Sprintf("k8sinstallerconfigtemplates.infrastructure.cluster.x-k8s.io %q not found", defaultK8sInstallerConfigTemplateName)))
 
 				createdK8sInstallerConfig := &infrastructurev1beta1.K8sInstallerConfig{}
 				err = k8sClientUncached.Get(ctx, byoMachineLookupKey, createdK8sInstallerConfig)

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func setFlags() {
 // main() will have lots of 'if', '&&' and '||' which will
 // increase its cyclometric complexity. Ignoring it for now.
 
-// nolint: funlen
+// nolint: funlen, gocyclo
 func main() {
 	setFlags()
 	ctrl.SetLogger(klogr.New())
@@ -153,6 +153,10 @@ func main() {
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "BootstrapKubeconfig")
+		os.Exit(1)
+	}
+	if err = (&infrastructurev1beta1.BootstrapKubeconfig{}).SetupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "BootstrapKubeconfig")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a new validation webhook for BootstrapKubeconfig object
For a create / update operation,
- rejects if APIServer is empty
- rejects if APIServer is not of the form `https://hostname:port`
- rejects if CertificateAuthorityData is empty
- rejects if CertificateAuthorityData is not PEM encoded

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #605 
