### PR TITLE
Fix Host Agent integration tests

### DIFF
--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -177,4 +177,11 @@ func cleanup(ctx context.Context, byoHostContainer *container.ContainerCreateCre
 			e2e.Showf("error removing log file %s: %v", agentLogFile, err)
 		}
 	}
+	_, err = os.Stat(e2e.TempKubeconfigPath)
+	if err == nil {
+		err = os.Remove(e2e.TempKubeconfigPath)
+		if err != nil {
+			e2e.Showf("error removing kubeconfig file %s: %v", e2e.TempKubeconfigPath, err)
+		}
+	}
 }

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -27,7 +27,7 @@ import (
 
 const (
 	kindImage           = "byoh/node:e2e"
-	tempKubeconfigPath  = "/tmp/mgmt.conf"
+	TempKubeconfigPath  = "/tmp/mgmt.conf"
 	bootstrapKubeconfig = "/tmp/boostrap-kubeconfig"
 )
 
@@ -189,6 +189,7 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 
 		re := regexp.MustCompile("server:.*")
 		kubeconfig = re.ReplaceAll(kubeconfig, []byte("server: https://127.0.0.1:"+r.Port))
+		Expect(os.WriteFile(TempKubeconfigPath, kubeconfig, 0644)).NotTo(HaveOccurred()) // nolint: gosec,gomnd
 
 		// If the --bootstrap-kubeconfig is not provided, the tests will use
 		// kubeconfig placed in ~/.byoh/config
@@ -218,12 +219,11 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 			err = r.DockerClient.ContainerExecStart(r.Context, execCommand.ID, types.ExecStartCheck{})
 			Expect(err).ShouldNot(HaveOccurred())
 
-			Expect(os.WriteFile(tempKubeconfigPath, kubeconfig, 0644)).NotTo(HaveOccurred()) // nolint: gosec,gomnd
-			config.sourcePath = tempKubeconfigPath
+			config.sourcePath = TempKubeconfigPath
 			// SplitAfterN used to remove the unwanted special characters in the homeDir
 			config.destPath = strings.SplitAfterN(strings.TrimSpace(homeDir)+"/.byoh/config", "/", 2)[1] // nolint: gomnd
 		} else {
-			config.sourcePath = tempKubeconfigPath
+			config.sourcePath = TempKubeconfigPath
 			config.destPath = r.CommandArgs["--bootstrap-kubeconfig"]
 		}
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Integration tests for Host Agent are failing as the `EnvTest` created kubeconfig is not copied to `/tmp/mgmt.conf`. This PR fixes that. 
Also to discover such issues in the future, we are also removing `/tmp/mgmt.conf` after each test execution

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #636 