### PR TITLE
Update the command to retrieve bootstrap-kubeconfig file

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -106,7 +106,7 @@ EOF
 
 Once the BootstrapKubeconfig CR is created, fetch the object to copy the bootstrap kubeconfig file details from the Status field
 ```shell
-kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o json | jq '.status'
+kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig
 ```
 Copy contents into a file called bootstrap-kubeconfig
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -106,9 +106,8 @@ EOF
 
 Once the BootstrapKubeconfig CR is created, fetch the object to copy the bootstrap kubeconfig file details from the Status field
 ```shell
-kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig
+kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig.conf
 ```
-Copy contents into a file called bootstrap-kubeconfig
 
 We need one bootstrap-kubeconfig per host. Create as many bootstrap-kubeconfig files as there are number of hosts (2 for this guide)
 
@@ -148,7 +147,6 @@ If you are trying this on your own hosts, then for each host
 If you are trying this using the docker containers we started above, then we would first need to prep the kubeconfig to be used from the docker containers. By default, the kubeconfig states that the server is at `127.0.0.1`. We need to swap this out with the kind container IP. 
 
 ```shell
-cp ~/bootstrap-kubeconfig ~/bootstrap-kubeconfig.conf
 export KIND_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)
 sed -i 's/    server\:.*/    server\: https\:\/\/'"$KIND_IP"'\:6443/g' ~/bootstrap-kubeconfig.conf
 ```

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -102,7 +102,7 @@ EOF
 
 Once the BootstrapKubeconfig CR is created, fetch the object to copy the bootstrap kubeconfig file details from the Status field
 ```shell
-kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o json | jq '.status'
+kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig
 ```
 Copy contents into a file called bootstrap-kubeconfig
 

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -102,9 +102,8 @@ EOF
 
 Once the BootstrapKubeconfig CR is created, fetch the object to copy the bootstrap kubeconfig file details from the Status field
 ```shell
-kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig
+kubectl get bootstrapkubeconfig bootstrap-kubeconfig -n default -o=jsonpath='{.status.bootstrapKubeconfigData}' > ~/bootstrap-kubeconfig.conf
 ```
-Copy contents into a file called bootstrap-kubeconfig
 
 We need one bootstrap-kubeconfig per host. Create as many bootstrap-kubeconfig files as there are number of hosts (2 for this guide)
 
@@ -113,7 +112,6 @@ We need one bootstrap-kubeconfig per host. Create as many bootstrap-kubeconfig f
 
 Create Management Cluster kubeconfig
 ```shell
-cp ~/bootstrap-kubeconfig ~/bootstrap-kubeconfig.conf
 export KIND_IP=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' kind-control-plane)
 sed -i 's/    server\:.*/    server\: https\:\/\/'"$KIND_IP"'\:6443/g' ~/bootstrap-kubeconfig.conf
 ```


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the command to retrieve the bootstrap-kubeconfig file content from BootstrapKubeconfig CR.
This was suggested by @mayur-tolexo in the issue thread on slack - https://kubernetes.slack.com/archives/C8TSNPY4T/p1659619114328639?thread_ts=1659557712.983069&cid=C8TSNPY4T

Tested on my local - seems to be working fine now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #671 
