### PR TITLE
New permission added for resource events

### DIFF
--- a/config/rbac/byohost_editor_role.yaml
+++ b/config/rbac/byohost_editor_role.yaml
@@ -25,6 +25,7 @@ rules:
   - patch
   - update
 - apiGroups:
+  - ""
   - byohosts
   resources:
   - events


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables clusterRole `byohost-editor-role` to  CURD events in empty apigroups.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #707 

**Additional information**
After adding PR changes. k8s Node bootstrapped successfully.

Warning without changes:
![Screenshot 2022-09-16 at 12 50 06 PM](https://user-images.githubusercontent.com/15645218/190580040-099cc9c5-81b8-47f4-8ac5-db7b05788ada.png)

No warning after changes
![Screenshot 2022-09-16 at 12 50 39 PM](https://user-images.githubusercontent.com/15645218/190580144-286395e2-d38f-4b8a-a70b-c2aee7c1cb9b.png)

**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->