### PR TITLE
Update golangci-lint v1.50.0. Enable linter dupword

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,5 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v2
       with:
-        version: v1.46.2
+        version: v1.50.0
         skip-go-installation: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.46.2 # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.0 # use the fixed version to not introduce new linters unexpectedly
 
 run:
   skip-dirs:
@@ -18,6 +18,7 @@ linters:
     - depguard
     - dogsled
     - dupl
+    - dupword
     - errcheck
     - funlen
     - goconst

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
 lint: golangci-lint
 	${GOLANGCI_LINT} run
 golangci-lint:
-	[ -e ${GOLANGCI_LINT} ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin v1.42.0
+	[ -e ${GOLANGCI_LINT} ] || curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell pwd)/bin v1.50.0
 
 ##@ Build
 

--- a/agent/help_flag_test.go
+++ b/agent/help_flag_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: nolintlint,testpackage
 package main
 
 import (

--- a/agent/host_agent_suite_test.go
+++ b/agent/host_agent_suite_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: nolintlint,testpackage
 package main
 
 import (

--- a/agent/host_agent_test.go
+++ b/agent/host_agent_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: nolintlint,testpackage
 package main
 
 import (

--- a/agent/label_flag_test.go
+++ b/agent/label_flag_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: nolintlint,testpackage
 package main
 
 import (

--- a/agent/main.go
+++ b/agent/main.go
@@ -51,7 +51,7 @@ func (l *labelFlags) String() string {
 }
 
 // Set implements flag.Value interface
-// nolint: gomnd
+//nolint: gomnd
 func (l *labelFlags) Set(value string) error {
 	// account for comma-separated key-value pairs in a single invocation
 	if len(strings.Split(value, ",")) > 1 {

--- a/agent/registration/host_registrar_test.go
+++ b/agent/registration/host_registrar_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Host Registrar Tests", func() {
 		Expect(k8sClient.Delete(ctx, byoHost)).ToNot(HaveOccurred())
 	})
 
-	Context("When a a ByoHost exists and registration is done", func() {
+	Context("When a ByoHost exists and registration is done", func() {
 		It("Should update the host details on the byohost successfully", func() {
 			Expect(hr.UpdateHost(ctx, byoHost)).ToNot(HaveOccurred())
 		})

--- a/apis/infrastructure/v1beta1/byohost_webhook.go
+++ b/apis/infrastructure/v1beta1/byohost_webhook.go
@@ -25,7 +25,7 @@ type ByoHostValidator struct {
 // To allow byoh manager service account to patch ByoHost CR
 const managerServiceAccount = "system:serviceaccount:byoh-system:byoh-controller-manager"
 
-// nolint: gocritic
+//nolint: gocritic
 // Handle handles all the requests for ByoHost resource
 func (v *ByoHostValidator) Handle(ctx context.Context, req admission.Request) admission.Response {
 	var response admission.Response
@@ -53,7 +53,7 @@ func (v *ByoHostValidator) handleCreateUpdate(req *admission.Request) admission.
 		return admission.Allowed("")
 	}
 	substrs := strings.Split(userName, ":")
-	if len(substrs) < 2 { // nolint: gomnd
+	if len(substrs) < 2 { //nolint: gomnd
 		return admission.Denied(fmt.Sprintf("%s is not a valid agent username", userName))
 	}
 	if !strings.Contains(byoHost.Name, substrs[2]) {

--- a/common/bootstraptoken/token.go
+++ b/common/bootstraptoken/token.go
@@ -18,7 +18,7 @@ import (
 // GetTokenIDSecretFromBootstrapToken splits the token string and returns the tokenID and tokenSecret parts
 func GetTokenIDSecretFromBootstrapToken(tokenStr string) (tokenID, tokenSecret string, err error) {
 	substrs := bootstraputil.BootstrapTokenRegexp.FindStringSubmatch(tokenStr)
-	if len(substrs) != 3 { // nolint: gomnd
+	if len(substrs) != 3 { //nolint: gomnd
 		return "", "", fmt.Errorf("the bootstrap token %q was not of the form %q", tokenStr, bootstrapapi.BootstrapTokenPattern)
 	}
 

--- a/controllers/infrastructure/byomachine_controller.go
+++ b/controllers/infrastructure/byomachine_controller.go
@@ -83,7 +83,7 @@ type ByoMachineReconciler struct {
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.8.3/pkg/reconcile
 
 // Reconcile handles ByoMachine events
-// nolint: gocyclo, funlen
+//nolint: gocyclo, funlen
 func (r *ByoMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Reconcile request received")

--- a/installer/bundle_downloader_test.go
+++ b/installer/bundle_downloader_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package installer
 
 import (

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func setFlags() {
 // main() will have lots of 'if', '&&' and '||' which will
 // increase its cyclometric complexity. Ignoring it for now.
 
-// nolint: funlen, gocyclo
+//nolint: funlen, gocyclo
 func main() {
 	setFlags()
 	ctrl.SetLogger(klogr.New())

--- a/test/e2e/byohost_reuse_test.go
+++ b/test/e2e/byohost_reuse_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/clusterclass_upgrade_test.go
+++ b/test/e2e/clusterclass_upgrade_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -19,7 +19,7 @@ import (
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/archive"
 	"github.com/docker/docker/pkg/system"
-	. "github.com/onsi/gomega" // nolint: stylecheck
+	. "github.com/onsi/gomega" //nolint: stylecheck
 	"github.com/pkg/errors"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/cluster-api/test/framework"
@@ -189,7 +189,7 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 
 		re := regexp.MustCompile("server:.*")
 		kubeconfig = re.ReplaceAll(kubeconfig, []byte("server: https://127.0.0.1:"+r.Port))
-		Expect(os.WriteFile(TempKubeconfigPath, kubeconfig, 0644)).NotTo(HaveOccurred()) // nolint: gosec,gomnd
+		Expect(os.WriteFile(TempKubeconfigPath, kubeconfig, 0644)).NotTo(HaveOccurred()) //nolint: gosec,gomnd
 
 		// If the --bootstrap-kubeconfig is not provided, the tests will use
 		// kubeconfig placed in ~/.byoh/config
@@ -221,7 +221,7 @@ func (r *ByoHostRunner) copyKubeconfig(config cpConfig, listopt types.ContainerL
 
 			config.sourcePath = TempKubeconfigPath
 			// SplitAfterN used to remove the unwanted special characters in the homeDir
-			config.destPath = strings.SplitAfterN(strings.TrimSpace(homeDir)+"/.byoh/config", "/", 2)[1] // nolint: gomnd
+			config.destPath = strings.SplitAfterN(strings.TrimSpace(homeDir)+"/.byoh/config", "/", 2)[1] //nolint: gomnd
 		} else {
 			config.sourcePath = TempKubeconfigPath
 			config.destPath = r.CommandArgs["--bootstrap-kubeconfig"]

--- a/test/e2e/e2e_clusterclass_test.go
+++ b/test/e2e/e2e_clusterclass_test.go
@@ -1,7 +1,7 @@
 // Copyright 2022 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/e2e_installer_test.go
+++ b/test/e2e/e2e_installer_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (

--- a/test/e2e/md_scale_test.go
+++ b/test/e2e/md_scale_test.go
@@ -1,7 +1,7 @@
 // Copyright 2021 VMware, Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-// nolint: testpackage
+//nolint: testpackage
 package e2e
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

* Updates `golangci-lint` to version v1.50.0.
* Enables linter dupword. A simple but common issue
* Fixes the new findings: for example removing a space in `//nolint` and adding `nolintlint` where there are no linting findings.

