### PR TITLE
update metadata for 0.4.0 upcoming release

### DIFF
--- a/controllers/infrastructure/byomachine_controller_test.go
+++ b/controllers/infrastructure/byomachine_controller_test.go
@@ -358,6 +358,13 @@ var _ = Describe("Controllers/ByomachineController", func() {
 					Expect(ph.Patch(ctx, byoHost, patch.WithStatusObservedGeneration{})).Should(Succeed())
 
 					WaitForObjectToBeUpdatedInCache(byoHost, func(object client.Object) bool {
+						return object.(*infrastructurev1beta1.ByoHost).Status.HostDetails == infrastructurev1beta1.HostInfo{
+							OSName:       "linux",
+							OSImage:      "Ubuntu 20.04.4 LTS",
+							Architecture: "arm64",
+						}
+					})
+					WaitForObjectToBeUpdatedInCache(byoHost, func(object client.Object) bool {
 						return object.(*infrastructurev1beta1.ByoHost).Status.MachineRef != nil
 					})
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -10,4 +10,7 @@ releaseSeries:
   - major: 0
     minor: 3
     contract: v1beta1
+  - major: 0
+    minor: 4
+    contract: v1beta1
 

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -62,7 +62,7 @@ providers:
   - name: byoh
     type: InfrastructureProvider
     versions:
-      - name: v0.3.0
+      - name: v0.4.0
         # Use manifest from source files
         value: ../../../config/default
         type: kustomize


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR is to update `metadata.yaml` for the `0.4.0` upcoming release with Kubernetes `v1.25.11` support. A flake in one of the controller tests is also fixed along with that.