### PR TITLE
Added support for K8s v1.26.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
       runs-on: ubuntu-20.04
       steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.10
+          go-version: 1.20.7
 
       - name: build agent
         run: make host-agent-binaries
@@ -40,9 +40,12 @@ jobs:
     steps:
     - name: Check Docker Version
       run: docker --version
-      
+    
+    - name: Uninstall podman if installed
+      run: sudo apt-get purge podman && sudo rm -rf /etc/cni/net.d/
+
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -53,9 +56,9 @@ jobs:
       run: sudo sysctl -w net.netfilter.nf_conntrack_max=131072
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19.10
+        go-version: 1.20.7
 
     - name: Install ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2

--- a/.github/workflows/draft-release.yaml
+++ b/.github/workflows/draft-release.yaml
@@ -12,12 +12,12 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19.10
+          go-version: 1.20.7
 
       - name: Build Release Artifacts
         run: IMG="projects.registry.vmware.com/cluster_api_provider_bringyourownhost/cluster-api-byoh-controller:${{ github.ref_name }}" make build-release-artifacts

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19.10
+        go-version: 1.20.7
 
     - name: Install ginkgo
       run: go install github.com/onsi/ginkgo/v2/ginkgo@v2.9.2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,16 +15,16 @@ jobs:
   golangci:
     runs-on: ubuntu-20.04
     steps:
-    - name: Install Go 1.19.10
-      uses: actions/setup-go@v2
+    - name: Install Go 1.20.7
+      uses: actions/setup-go@v4
       with:
-        go-version: 1.19.10
+        go-version: 1.20.7
 
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: golangci-lint
-      uses: golangci/golangci-lint-action@v2
+      uses: golangci/golangci-lint-action@v3
       with:
-        version: v1.50.0
+        version: v1.51.0
         skip-go-installation: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19.10 as builder
+FROM golang:1.20.7 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ host-agent-binary: $(RELEASE_DIR)
 		-e GOARCH=$(GOARCH) \
 		-v "$$(pwd):/workspace$(DOCKER_VOL_OPTS)" \
 		-w /workspace \
-		golang:1.19.10 \
+		golang:1.20.7 \
 		go build -buildvcs=false -a -ldflags "$(GOLDFLAGS)" \
 		-o ./bin/$(notdir $(RELEASE_BINARY))-$(GOOS)-$(GOARCH) $(HOST_AGENT_DIR)
 

--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ If someone wants to implement their own installer controller then they need to f
 - BYOH is currently compatible wth Cluster API v1beta1 (v1.0)
 
 ## Supported OS and Kubernetes versions
-| Operating System  | Architecture  | Kubernetes v1.22.* | Kubernetes v1.23.* | Kubernetes v1.24.* | Kubernetes v1.25.* |
-| ------------------|---------------|:------------------:|:------------------:|:------------------:|:------------------:|
-| Ubuntu 20.04.*    | amd64         |         ✓          |         ✓          |         ✓          |         ✓          |
+| Operating System  | Architecture  | Kubernetes v1.24.* | Kubernetes v1.25.* | Kubernetes v1.26.* |
+| ------------------|---------------|:------------------:|:------------------:|:------------------:|
+| Ubuntu 20.04.*    | amd64         |         ✓          |         ✓          |         ✓          |
 
 **NOTE:**  The '*' in OS means that all Ubuntu 20.04 patches are supported.
 

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -231,7 +231,11 @@ func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	}
 
 	if len(errList) > 0 {
-		return errors.New("not all k8s directories are cleaned up")
+		errs := errList[0]                //nolint: gosec
+		for i, err := range errList[1:] { //nolint: gosec
+			errs = fmt.Errorf("%w; %d error", err, i)
+		}
+		return errors.WithMessage(errs, "not all k8s directories are cleaned up")
 	}
 	return nil
 }

--- a/agent/reconciler/host_reconciler.go
+++ b/agent/reconciler/host_reconciler.go
@@ -231,11 +231,11 @@ func (r *HostReconciler) cleank8sdirectories(ctx context.Context) error {
 	}
 
 	if len(errList) > 0 {
-		errs := errList[0]                //nolint: gosec
-		for i, err := range errList[1:] { //nolint: gosec
-			errs = fmt.Errorf("%w; %d error", err, i)
+		err := errList[0]               //nolint: gosec
+		for _, e := range errList[1:] { //nolint: gosec
+			err = fmt.Errorf("%w; %v error", err, e)
 		}
-		return errors.WithMessage(errs, "not all k8s directories are cleaned up")
+		return errors.WithMessage(err, "not all k8s directories are cleaned up")
 	}
 	return nil
 }

--- a/docs/BYOHDockerFileDev
+++ b/docs/BYOHDockerFileDev
@@ -16,7 +16,7 @@ RUN echo "Installing kubectl kubeadm kubelet" \
     && curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
     && apt-get update \
     && apt-get install -y linux-image-$(uname -r) \
-    && apt-get install -y kubelet=1.25.11-00 kubeadm=1.25.11-00 kubectl=1.25.11-00 \
+    && apt-get install -y kubelet=1.26.6-00 kubeadm=1.26.6-00 kubectl=1.26.6-00 \
     && apt-mark hold containerd kubelet kubeadm kubectl \
     && apt-get clean \
     && systemctl enable kubelet.service \

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -205,7 +205,7 @@ Generate the cluster.yaml for workload cluster
     ```shell
     CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
       --infrastructure byoh \
-      --kubernetes-version v1.25.11 \
+      --kubernetes-version v1.26.6 \
       --control-plane-machine-count 1 \
       --worker-machine-count 1 > cluster.yaml
     ```
@@ -214,7 +214,7 @@ Generate the cluster.yaml for workload cluster
     ```shell
     CONTROL_PLANE_ENDPOINT_IP=10.10.10.10 clusterctl generate cluster byoh-cluster \
         --infrastructure byoh \
-        --kubernetes-version v1.25.11 \
+        --kubernetes-version v1.26.6 \
         --control-plane-machine-count 1 \
         --worker-machine-count 1 \
         --flavor docker > cluster.yaml
@@ -253,7 +253,7 @@ after that you should see your nodes turn into ready:
 ```shell
 $ KUBECONFIG=byoh-cluster.kubeconfig kubectl get nodes
 NAME                                                          STATUS     ROLES    AGE   VERSION
-byoh-cluster-8siai8                                           Ready      master   5m   v1.25.11
+byoh-cluster-8siai8                                           Ready      master   5m   v1.26.6
 ```
 
 ## Additional: Running host-agent as a systemd service

--- a/docs/local_dev.md
+++ b/docs/local_dev.md
@@ -233,23 +233,18 @@ Note: It may happen that a specific patch version of a k8s minor release is not 
     </tr>
     <tr>
         <td>Ubuntu_20.04.*_x86-64</td>
-        <td>v1.22.*</td>
-        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.22.*</td>
-    </tr>
-        <tr>
-        <td>Ubuntu_20.04.*_x86-64</td>
-        <td>v1.23.*</td>
-        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.23.*</td>
-    </tr>
-    <tr>
-        <td>Ubuntu_20.04.*_x86-64</td>
         <td>v1.24.*</td>
         <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.24.*</td>
     </tr>
-        <tr>
+    <tr>
         <td>Ubuntu_20.04.*_x86-64</td>
         <td>v1.25.*</td>
         <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.25.*</td>
+    </tr>
+        <tr>
+        <td>Ubuntu_20.04.*_x86-64</td>
+        <td>v1.26.*</td>
+        <td>byoh-bundle-ubuntu_20.04.1_x86-64_k8s:v1.26.*</td>
     </tr>
 </table>
 The '*' in OS means that all Ubuntu 20.04 patches will be handled by this BYOH bundle.

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/vmware-tanzu/cluster-api-provider-bringyourownhost
 
-go 1.19
+go 1.20
 
 replace github.com/insomniacslk/dhcp => github.com/harvester/dhcp v0.0.0-20220421024905-28b38eafefe3
 
 require (
-	github.com/docker/cli v23.0.1+incompatible
-	github.com/docker/docker v23.0.3+incompatible
+	github.com/docker/cli v24.0.5+incompatible
+	github.com/docker/docker v24.0.5+incompatible
 	github.com/go-logr/logr v1.2.3
 	github.com/jackpal/gateway v1.0.7
 	github.com/kube-vip/kube-vip v0.5.5

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ cloud.google.com/go/storage v1.8.0/go.mod h1:Wv1Oy7z6Yz3DshWRJFhqM/UCfaWIRTdp0RX
 cloud.google.com/go/storage v1.10.0/go.mod h1:FLPqc6j+Ki4BU591ie1oL6qBQGu2Bl/tZ9ullr3+Kg0=
 cloud.google.com/go/storage v1.14.0/go.mod h1:GrKmX003DSIwi9o29oFT7YDnHYwZoctc3fOKtUw0Xmo=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20210715213245-6c3934b029d8 h1:V8krnnfGj4pV65YLUm3C0/8bl7V5Nry2Pwvy3ru/wLc=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
@@ -117,7 +118,6 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/containerd/containerd v1.6.18 h1:qZbsLvmyu+Vlty0/Ex5xc0z2YtKpIsb5n45mAMI+2Ns=
 github.com/containerd/containerd v1.6.18/go.mod h1:1RdCUu95+gc2v9t3IL+zIlpClSmew7/0YS8O5eQZrOw=
-github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvAXZJ/eg=
 github.com/coredns/caddy v1.1.0 h1:ezvsPrT/tA/7pYDBZxu0cT0VmWk75AfIaf6GSYCNMf0=
 github.com/coredns/caddy v1.1.0/go.mod h1:A6ntJQlAWuQfFlsd9hvigKbo2WS0VUs2l1e2F+BawD4=
 github.com/coredns/corefile-migration v1.0.20 h1:MdOkT6F3ehju/n9tgxlGct8XAajOX2vN+wG7To4BWSI=
@@ -144,13 +144,13 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/denisenkom/go-mssqldb v0.0.0-20191128021309-1d7a30a10f73/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
-github.com/docker/cli v23.0.1+incompatible h1:LRyWITpGzl2C9e9uGxzisptnxAn1zfZKXy13Ul2Q5oM=
-github.com/docker/cli v23.0.1+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
+github.com/docker/cli v24.0.5+incompatible h1:WeBimjvS0eKdH4Ygx+ihVq1Q++xg36M/rMi4aXAvodc=
+github.com/docker/cli v24.0.5+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/distribution v2.8.2+incompatible h1:T3de5rq0dB1j30rp0sA2rER+m322EBzniBPB6ZIzuh8=
 github.com/docker/distribution v2.8.2+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v23.0.3+incompatible h1:9GhVsShNWz1hO//9BNg/dpMnZW25KydO4wtVxWAIbho=
-github.com/docker/docker v23.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v24.0.5+incompatible h1:WmgcE4fxyI6EEXxBRxsHnZXrO1pQ3smi0k/jho4HLeY=
+github.com/docker/docker v24.0.5+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=
 github.com/docker/docker-credential-helpers v0.7.0/go.mod h1:rETQfLdHNT3foU5kuNkFR1R1V12OJRRO5lzt2D1b5X0=
 github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c h1:lzqkGL9b3znc+ZUgi7FlLnqjQhcXxkNM/quxIjBVMD0=

--- a/hack/getting_started.sh
+++ b/hack/getting_started.sh
@@ -537,7 +537,7 @@ manageClusterConfFile="${HOME}/.kube/management-cluster.conf"
 kubeConfigFile=/tmp/byoh-cluster-kubeconfig
 reposDir=$(dirname $0)/../
 byohBinaryFile=${reposDir}/bin/byoh-hostagent-linux-amd64
-kubernetesVersion="v1.25.11"
+kubernetesVersion="v1.26.6"
 
 readArgs $@
 userConfirmation

--- a/installer/bundle_builder/ingredients/deb/Dockerfile
+++ b/installer/bundle_builder/ingredients/deb/Dockerfile
@@ -13,7 +13,7 @@ FROM $BASE_IMAGE as build
 
 # Override to download other version
 ENV CONTAINERD_VERSION=1.6.18
-ENV KUBERNETES_VERSION=1.25.11-00
+ENV KUBERNETES_VERSION=1.26.6-00
 ENV ARCH=amd64
 
 RUN apt-get update \

--- a/installer/registry.go
+++ b/installer/registry.go
@@ -115,19 +115,18 @@ func GetSupportedRegistry() registry {
 
 		// BYOH Bundle Repository. Associate bundle with installer
 		linuxDistro := "Ubuntu_20.04.1_x86-64"
-		reg.AddBundleInstaller(linuxDistro, "v1.23.*")
 		reg.AddBundleInstaller(linuxDistro, "v1.24.*")
 		reg.AddBundleInstaller(linuxDistro, "v1.25.*")
+		reg.AddBundleInstaller(linuxDistro, "v1.26.*")
 
 		/*
 		 * PLACEHOLDER - ADD MORE K8S VERSIONS HERE
 		 */
 
 		// Match any patch version of the specified Major & Minor K8s version
-		reg.AddK8sFilter("v1.22.*")
-		reg.AddK8sFilter("v1.23.*")
 		reg.AddK8sFilter("v1.24.*")
 		reg.AddK8sFilter("v1.25.*")
+		reg.AddK8sFilter("v1.26.*")
 
 		// Match concrete os version to repository os version
 		reg.AddOsFilter("Ubuntu_20.04.*_x86-64", linuxDistro)

--- a/installer/registry_internal_test.go
+++ b/installer/registry_internal_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Byohost Installer Tests", func() {
 			Expect(osBundles).To(HaveLen(1))
 
 			osBundleResult := r.ListK8s("Ubuntu_20.04.1_x86-64")
-			Expect(osBundleResult).To(ContainElements("v1.23.*", "v1.24.*", "v1.25.*"))
+			Expect(osBundleResult).To(ContainElements("v1.24.*", "v1.25.*", "v1.26.*"))
 			Expect(osBundleResult).To(HaveLen(3))
 		})
 	})

--- a/test/e2e/cluster_upgrade_test.go
+++ b/test/e2e/cluster_upgrade_test.go
@@ -35,8 +35,8 @@ var _ = Describe("Cluster upgrade test [K8s-upgrade]", func() {
 		dockerClient                 *client.Client
 		allbyohostContainerIDs       []string
 		allAgentLogFiles             []string
-		kubernetesVersionUpgradeFrom = "v1.24.2"
-		kubernetesVersionUpgradeTo   = "v1.25.11"
+		kubernetesVersionUpgradeFrom = "v1.25.11"
+		kubernetesVersionUpgradeTo   = "v1.26.6"
 		etcdUpgradeVersion           = "3.5.6-0"
 		coreDNSUpgradeVersion        = "v1.9.3"
 	)

--- a/test/e2e/clusterclass_upgrade_test.go
+++ b/test/e2e/clusterclass_upgrade_test.go
@@ -35,8 +35,8 @@ var _ = Describe("Clusterclass upgrade test [K8s-upgrade]", func() {
 		dockerClient                 *client.Client
 		allbyohostContainerIDs       []string
 		allAgentLogFiles             []string
-		kubernetesVersionUpgradeFrom = "v1.24.2"
-		kubernetesVersionUpgradeTo   = "v1.25.11"
+		kubernetesVersionUpgradeFrom = "v1.25.11"
+		kubernetesVersionUpgradeTo   = "v1.26.6"
 		etcdUpgradeVersion           = "3.5.6-0"
 		coreDNSUpgradeVersion        = "v1.9.3"
 	)

--- a/test/e2e/config/provider.yaml
+++ b/test/e2e/config/provider.yaml
@@ -86,7 +86,7 @@ providers:
 variables:
   # default variables for the e2e test; those values could be overridden via env variables, thus
   # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
-  KUBERNETES_VERSION: "v1.25.11"
+  KUBERNETES_VERSION: "v1.26.6"
   ETCD_VERSION_UPGRADE_TO: "3.5.6-0"
   COREDNS_VERSION_UPGRADE_TO: "1.9.3"
   KUBERNETES_VERSION_UPGRADE_TO: "v1.22.0"
@@ -103,7 +103,7 @@ variables:
   NODE_DRAIN_TIMEOUT: "60s"
   # NOTE: INIT_WITH_BINARY is used only by the clusterctl upgrade test to initialize the management cluster to be upgraded
   INIT_WITH_BINARY: "https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.4.4/clusterctl-{OS}-{ARCH}"
-  BUNDLE_LOOKUP_TAG: "v1.25.11"
+  BUNDLE_LOOKUP_TAG: "v1.26.6"
   CONTROL_PLANE_ENDPOINT_IP: ""
   MANUAL_CSR_APPROVAL: "disable"
 

--- a/test/e2e/docker_helper.go
+++ b/test/e2e/docker_helper.go
@@ -59,7 +59,7 @@ func resolveLocalPath(localPath string) (absPath string, err error) {
 	if absPath, err = filepath.Abs(localPath); err != nil {
 		return
 	}
-	return archive.PreserveTrailingDotOrSeparator(absPath, localPath, filepath.Separator), nil
+	return archive.PreserveTrailingDotOrSeparator(absPath, localPath), nil
 }
 
 func copyToContainer(ctx context.Context, cli *client.Client, copyConfig cpConfig) (err error) {

--- a/test/e2e/e2e_suite_test.go
+++ b/test/e2e/e2e_suite_test.go
@@ -192,7 +192,7 @@ func setupBootstrapCluster(config *clusterctl.E2EConfig, scheme *runtime.Scheme,
 	if !useExistingCluster {
 		clusterProvider = bootstrap.CreateKindBootstrapClusterAndLoadImages(context.TODO(), bootstrap.CreateKindBootstrapClusterAndLoadImagesInput{
 			Name:               config.ManagementClusterName,
-			KubernetesVersion:  "v1.25.11",
+			KubernetesVersion:  "v1.26.6",
 			RequiresDockerSock: config.HasDockerProvider(),
 			Images:             config.Images,
 			IPFamily:           config.GetVariable(IPFamily),


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds support for K8s `v1.26.6`

**Which issue(s) this PR fixes** :
Fixes #797 

**Additional information**

- `Go` version is also bumped to `1.20.7`
- GH Actions(`actions/checkout`, `actions/setup-go`) bumped to newer version.
- GH Action `golangci-lint-action` is bumped to V3 and the binary version is bumped to `v1.51.0`
