### PR TITLE
Add support for specifying platform and target arch in the manager image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 # Build the manager binary
-FROM golang:1.20.7 as builder
+FROM --platform=$BUILDPLATFORM golang:1.20.7 as builder
+
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -18,7 +20,7 @@ COPY installer/ installer/
 COPY common/ common/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH go build -a -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for building ARM manager images

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Doesn't fix, but works towards implementing #251 

**Additional information**

I couldn't find exactly how images were built and published, so I haven't made any workflow changes.

Similarly, I wasn't sure if there were any good spots to add tests for this. If any tests need to/should be added please let me know!

**Special notes for your reviewer**

I am building the image manually in another project of mine and it's running fine in my raspberry pi management cluster at the moment. Here is the [dockerfile](https://github.com/UnstoppableMango/the-cluster/blob/main/containers/byoh/Dockerfile) and a [built image](https://github.com/UnstoppableMango/the-cluster/actions/runs/8166878930/job/22326361074)