### PR TITLE
truncate files if append is disabled

### DIFF
--- a/agent/cloudinit/file_writer.go
+++ b/agent/cloudinit/file_writer.go
@@ -56,6 +56,8 @@ func (w FileWriter) WriteToFile(file *Files) error {
 	flag := os.O_WRONLY | os.O_CREATE
 	if file.Append {
 		flag |= os.O_APPEND
+	} else {
+		flag |= os.O_TRUNC
 	}
 
 	f, err := os.OpenFile(file.Path, flag, initPermission)

--- a/agent/cloudinit/file_writer_test.go
+++ b/agent/cloudinit/file_writer_test.go
@@ -97,6 +97,31 @@ var _ = Describe("FileWriter", func() {
 
 	})
 
+	It("Should overwrite content of file when append mode is disabled", func() {
+		fileOriginContent := "very long long message"
+		file := cloudinit.Files{
+			Path:        path.Join(workDir, "file3.txt"),
+			Encoding:    "",
+			Owner:       "",
+			Permissions: "",
+			Content:     "short message",
+			Append:      false,
+		}
+
+		err := cloudinit.FileWriter{}.MkdirIfNotExists(workDir)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = os.WriteFile(file.Path, []byte(fileOriginContent), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = cloudinit.FileWriter{}.WriteToFile(&file)
+		Expect(err).NotTo(HaveOccurred())
+
+		buffer, err := os.ReadFile(file.Path)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(buffer)).To(Equal(file.Content))
+	})
+
 	It("should return error with invalid owner format", func() {
 		file := cloudinit.Files{
 			Path:        path.Join(workDir, "file1.txt"),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes cloud init write_files section when file already exists and append mode is disabled. Right now it only overwrites the first characters of an existing file, which may cause the file to become corrupted

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Additional information**


**Special notes for your reviewer**

<!-- Add notes to that can aid in the review process, or leave blank -->

<!--
If this pull request is just an idea or POC, or is not ready for review, select "Create draft pull request" (https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests)
instead of "Create pull request"
-->